### PR TITLE
Start AppSignal if APPSIGNAL_PUSH_API_KEY is configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "jbuilder"
 gem "bootsnap", require: false
 gem "solid_cable"
 gem "sqlite3", "~> 1.7.3"
+gem "appsignal"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    appsignal (3.7.5)
+      rack
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
@@ -372,6 +374,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  appsignal
   bootsnap
   brakeman
   capybara

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,26 @@
+default: &defaults
+  # Your app's name as reported on AppSignal.com. Required
+  name: "Shipyrd"
+
+  ignore_actions:
+    - "GET /up" # Ignore the /up endpoint for metrics
+
+  ignore_logs:
+    - "\"/up\"" # Ignore logs that contain "/up"
+
+  log: stdout
+
+# Configuration per environment, leave out an environment or set active
+# to false to not push metrics for that environment.
+development:
+  <<: *defaults
+  debug: true
+  active: false
+
+test:
+  <<: *defaults
+  active: false
+
+production:
+  <<: *defaults
+  active: <%= ENV["APPSIGNAL_PUSH_API_KEY"].present? %>


### PR DESCRIPTION
For my own error monitoring but useful for anyone else utilizing AppSignal if they'd like to opt-in. 