### PR TITLE
Always run solid queue via puma, set local puma-dev config

### DIFF
--- a/.pumaenv
+++ b/.pumaenv
@@ -1,0 +1,1 @@
+CONFIG=config/puma.rb

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,7 +8,7 @@ default: &default
       writing: cable
 
 development:
-  adapter: async
+  <<: *default
 
 test:
   adapter: test

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,4 +32,4 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+plugin :solid_queue


### PR DESCRIPTION
- .pumaenv is for puma-dev locally so that the plugins are properly loaded including solid_queue
- Default to always booting solid_queue via puma plugin