### PR TITLE
Spruce up the signup page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ Shipyrd is a deployment dashboard for [Kamal](https://kamal-deploy.org/)-based d
 ## Commands
 
 ```bash
+# Run full CI suite (lint, security, tests, system tests) — mirrors GitHub Actions
+bin/ci
+
 # Run all tests
 bundle exec rails test
 
@@ -64,3 +67,7 @@ Migrations live in `db/migrate/`, `db/queue_migrate/`, and `db/cable_migrate/` r
 **Billing:** Stripe integration; `Organization` tracks trial/subscription state. Incoming Stripe webhooks handled by `IncomingWebhooksController`.
 
 **Testing:** Minitest + fixtures. System tests use Selenium. No mocking of the database — tests hit the real DB.
+
+## Workflow
+
+After creating a PR, run `bin/ci` to catch failures before GitHub Actions runs. Fix any issues before moving on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,4 +70,4 @@ Migrations live in `db/migrate/`, `db/queue_migrate/`, and `db/cable_migrate/` r
 
 ## Workflow
 
-After creating a PR, run `bin/ci` to catch failures before GitHub Actions runs. Fix any issues before moving on.
+After creating a PR or pushing changes to an existing PR, run `bin/ci` to catch failures before GitHub Actions runs. Fix any issues before moving on.

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -58,3 +58,22 @@ progress.green {
   -webkit-user-select: all;
   user-select: all;
 }
+
+.signup-divider {
+  position: relative;
+}
+
+.signup-divider::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  border-top: 1px solid hsl(0, 0%, 86%);
+}
+
+.signup-divider span {
+  position: relative;
+  background: white;
+  padding: 0 1rem;
+}

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="field">
     <%= form.label :name, class: "label" %>
     <div class="control">
-      <%= form.text_field :name, class: "input", required: true %>
+      <%= form.text_field :name, class: "input", required: true, placeholder: "Your full name" %>
     </div>
   </div>
 
@@ -12,7 +12,7 @@
     <div class="field">
       <%= form.label :organization_name, class: "label" %>
       <div class="control">
-        <%= form.text_field :organization_name, class: "input", required: true %>
+        <%= form.text_field :organization_name, class: "input", required: true, placeholder: "Your team or company name" %>
       </div>
     </div>
   <% end %>
@@ -20,19 +20,26 @@
   <div class="field">
     <%= form.label :email, class: "label" %>
     <div class="control">
-      <%= form.text_field :email, class: "input", required: true %>
+      <%= form.text_field :email, class: "input", required: true, placeholder: "you@example.com" %>
     </div>
   </div>
 
   <div class="field">
     <%= form.label :password, class: "label" %>
     <div class="control">
-      <%= form.password_field :password, class: "input", required: true %>
+      <%= form.password_field :password, class: "input", required: true, placeholder: "At least 10 characters" %>
     </div>
   </div>
 
   <div class="field">
-    <%= form.submit class: "button is-primary" %>
-    <%= link_to "Create account with GitHub", oauth_authorize_url(:github), class: "button is-secondary" %>
+    <%= form.submit "Create account", class: "button is-primary is-fullwidth" %>
+  </div>
+
+  <div class="signup-divider has-text-centered my-4">
+    <span class="has-text-grey is-size-7">or</span>
+  </div>
+
+  <div class="field">
+    <%= link_to "Create account with GitHub", oauth_authorize_url(:github), class: "button is-fullwidth" %>
   </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,40 @@
 <div class="columns is-centered">
   <div class="column is-half">
-    <%= render "form", user: @user %>
-    <div class="mt-4 field">
+    <div class="has-text-centered mb-5">
+      <h1 class="title is-3 mb-4">Know what's deployed. Always.</h1>
+      <p class="subtitle is-5 has-text-grey">
+        The deployment dashboard for Kamal. See who deployed, what changed, and what's waiting to go out.
+      </p>
+    </div>
+
+    <div class="box">
+      <%= render "form", user: @user %>
+    </div>
+
+    <div class="mt-5">
+      <div class="columns is-mobile is-multiline has-text-centered">
+        <div class="column is-one-third">
+          <span class="icon has-text-primary mb-2">
+            <i class="fa-solid fa-timeline"></i>
+          </span>
+          <p class="is-size-7 has-text-grey">Deploy timeline</p>
+        </div>
+        <div class="column is-one-third">
+          <span class="icon has-text-primary mb-2">
+            <i class="fa-solid fa-lock"></i>
+          </span>
+          <p class="is-size-7 has-text-grey">Environment locking</p>
+        </div>
+        <div class="column is-one-third">
+          <span class="icon has-text-primary mb-2">
+            <i class="fa-brands fa-slack"></i>
+          </span>
+          <p class="is-size-7 has-text-grey">Slack notifications</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-4 field has-text-centered">
       <%= link_to "Sign in", new_session_path, class: "has-text-info is-clickable is-underlined" %>
       <% unless community_edition? %>
         <span class="has-text-info">&bull;</span>

--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -24,6 +24,8 @@ SHIPYRD_CABLE_DATABASE_URL=mysql2://root:root@127.0.0.1:3306/shipyrd_${WORKSPACE
 PORT=\${CONDUCTOR_PORT}
 SHIPYRD_HOST=localhost:\${CONDUCTOR_PORT}
 SHIPYRD_HOOKS_HOST=localhost:\${CONDUCTOR_PORT}
+
+COMMUNITY_EDITION=0
 EOF
 
 echo "Creating .env.test for workspace: $WORKSPACE_NAME..."

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,9 +23,9 @@ module Shipyrd
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
-    config.active_record.encryption.primary_key = ENV.fetch("SHIPYRD_ENCRYPTION_PRIMARY_KEY", "dev-primary-key-00000000000000000000")
-    config.active_record.encryption.deterministic_key = ENV.fetch("SHIPYRD_ENCRYPTION_DETERMINISTIC_KEY", "dev-deterministic-key-000000000000000")
-    config.active_record.encryption.key_derivation_salt = ENV.fetch("SHIPYRD_ENCRYPTION_KEY_DERIVATION_SALT", "dev-key-derivation-salt-00000000000")
+    config.active_record.encryption.primary_key = ENV["SHIPYRD_ENCRYPTION_PRIMARY_KEY"]
+    config.active_record.encryption.deterministic_key = ENV["SHIPYRD_ENCRYPTION_DETERMINISTIC_KEY"]
+    config.active_record.encryption.key_derivation_salt = ENV["SHIPYRD_ENCRYPTION_KEY_DERIVATION_SALT"]
 
     config.mission_control.jobs.base_controller_class = "SystemAdminController"
     config.mission_control.jobs.http_basic_auth_enabled = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,9 +23,9 @@ module Shipyrd
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
-    config.active_record.encryption.primary_key = ENV["SHIPYRD_ENCRYPTION_PRIMARY_KEY"]
-    config.active_record.encryption.deterministic_key = ENV["SHIPYRD_ENCRYPTION_DETERMINISTIC_KEY"]
-    config.active_record.encryption.key_derivation_salt = ENV["SHIPYRD_ENCRYPTION_KEY_DERIVATION_SALT"]
+    config.active_record.encryption.primary_key = ENV.fetch("SHIPYRD_ENCRYPTION_PRIMARY_KEY", "dev-primary-key-00000000000000000000")
+    config.active_record.encryption.deterministic_key = ENV.fetch("SHIPYRD_ENCRYPTION_DETERMINISTIC_KEY", "dev-deterministic-key-000000000000000")
+    config.active_record.encryption.key_derivation_salt = ENV.fetch("SHIPYRD_ENCRYPTION_KEY_DERIVATION_SALT", "dev-key-derivation-salt-00000000000")
 
     config.mission_control.jobs.base_controller_class = "SystemAdminController"
     config.mission_control.jobs.http_basic_auth_enabled = false

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -41,7 +41,7 @@ class UsersTest < ApplicationSystemTestCase
       fill_in "Email", with: @user.email
       fill_in "Password", with: "secretsecret"
 
-      click_on "Create User"
+      click_on "Create account"
 
       assert_text "Create your first application"
     end
@@ -64,7 +64,7 @@ class UsersTest < ApplicationSystemTestCase
       fill_in "Email", with: @user.email
       fill_in "Password", with: "secretsecret"
 
-      click_on "Create User"
+      click_on "Create account"
 
       assert_text "User was successfully created"
       assert_text "Create your first application"
@@ -82,7 +82,7 @@ class UsersTest < ApplicationSystemTestCase
       fill_in "Email", with: @user.email
       fill_in "Password", with: "secretsecret"
 
-      click_on "Create User"
+      click_on "Create account"
 
       assert_text "User was successfully created"
       assert_text "Create your first application"


### PR DESCRIPTION
## Summary

- Adds a headline and subtitle pulled from the marketing site ("Know what's deployed. Always.")
- Wraps the signup form in a box with placeholder text on all fields, full-width buttons, and an "or" divider between email signup and GitHub OAuth
- Adds feature highlight icons below the form (deploy timeline, environment locking, Slack notifications)
- Sets `COMMUNITY_EDITION=0` in `bin/conductor-setup` for dev workspaces