### PR TITLE
Improve test speed and fix Conductor encryption setup

### DIFF
--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -31,6 +31,9 @@ EOF
 echo "Creating .env.test for workspace: $WORKSPACE_NAME..."
 cat > .env.test <<EOF
 SHIPYRD_DATABASE_URL=mysql2://root:root@127.0.0.1:3306/shipyrd_${WORKSPACE_NAME}_test
+SHIPYRD_ENCRYPTION_PRIMARY_KEY=$(ruby -e "require 'securerandom'; puts SecureRandom.hex(16)")
+SHIPYRD_ENCRYPTION_DETERMINISTIC_KEY=$(ruby -e "require 'securerandom'; puts SecureRandom.hex(16)")
+SHIPYRD_ENCRYPTION_KEY_DERIVATION_SALT=$(ruby -e "require 'securerandom'; puts SecureRandom.hex(16)")
 EOF
 
 # Run full setup (dependencies, database, fixtures)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,7 +5,7 @@ require "helpers/system_auth"
 WebMock.allow_net_connect!
 
 Capybara.disable_animation = true
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 5
 Capybara.server = :puma, {Silent: true}
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/test/system/applications_test.rb
+++ b/test/system/applications_test.rb
@@ -81,8 +81,6 @@ class ApplicationsTest < ApplicationSystemTestCase
         )
       end
 
-      sleep(1)
-
       assert_content "by Nick"
       assert_content "Deploying the potato"
       refute_link "On Deck"
@@ -133,8 +131,6 @@ class ApplicationsTest < ApplicationSystemTestCase
       fill_in "Repository URL", with: "https://github.com/shipyrd/shipyrd"
 
       click_on "Update"
-
-      sleep(1)
 
       assert_text "Application was successfully updated"
     end


### PR DESCRIPTION
## Summary

- Remove two unnecessary `sleep(1)` calls in system tests that were adding ~2s of wasted time. Capybara's built-in waiting assertions handle the timing naturally.
- Reduce `Capybara.default_max_wait_time` from 10s to 5s — nothing needs waits longer than 5s, and this prevents slow negative assertions.
- Generate Active Record encryption keys in `bin/conductor-setup` so that tests touching `IncomingWebhook` and `OauthToken` models pass in Conductor workspaces (previously 10 test errors).