### PR TITLE
Fix inaccuracies in CLAUDE.md and README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,15 +56,15 @@ Migrations live in `db/migrate/`, `db/queue_migrate/`, and `db/cable_migrate/` r
 
 **Authentication — two paths:**
 1. User sessions (password or GitHub OAuth)
-2. Bearer token — either an `Application` token (for Kamal webhook deploys) or a `User` `ApiKey` token (for API calls); resolved in `ApplicationController#authenticate_with_token`
+2. Bearer token — either an `Application` token (for Kamal webhook deploys) or a `User` token (for API calls); resolved in `ApplicationController#authenticate`
 
 **Frontend:** No JS bundler — uses importmap. Stimulus controllers live in `app/javascript/controllers/`. CSS is Bulma + custom properties in `app/assets/stylesheets/application.css`.
 
 **Background jobs (Solid Queue):** `NotificationJob`, `AvatarImporterJob`, `CleanupOldDeploysJob`, `CreateStripeCustomerJob`. Mission Control UI at `/jobs` (admin only).
 
-**Notifications:** Notification channel integrations are in `app/models/channels/` (Slack, Discord, etc.). `lib/slack.rb` contains the low-level Slack client.
+**Notifications:** `Channel` is a polymorphic model (`app/models/channel.rb`) whose `owner` points to the integration type (`Webhook`, `OauthToken`). `lib/slack.rb` contains the low-level Slack client.
 
-**Billing:** Stripe integration; `Organization` tracks trial/subscription state. Incoming Stripe webhooks handled by `IncomingWebhooksController`.
+**Billing:** Stripe integration; `Organization` tracks trial/subscription state. Incoming Stripe webhooks handled by `Incoming::StripeController`.
 
 **Testing:** Minitest + fixtures. System tests use Selenium. No mocking of the database — tests hit the real DB.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The accessory configuration requires a few secrets:
 ``` yml
 accessories:
   shipyrd:
-    image: shipyrd/shipyrd:v0.3.5
+    image: shipyrd/shipyrd:v4.4.0
     host: 867.530.9
     proxy:
       host: shipyrd.myapp.com
@@ -106,20 +106,19 @@ With the triggers added to your Kamal hooks you'll now be able to see your app g
 
 ### Customizing the deploy performer
 
-Kamal sets `ENV['KAMAL_PERFORMER']` to your username on your computer via `git config user.email` or `whoami`, whichever it finds first. Shipyrd will instead fetch your GitHub username from your local configuration if it's set since this helps with linking over to GitHub and avatars. You can set your GitHub username in your local configuration via:
+Kamal sets `KAMAL_PERFORMER` to identify who is deploying — typically `git config user.email` or `whoami`. The Shipyrd gem forwards this value as the deploy's `performer`. For Shipyrd to match a deploy to the correct user (which matters for deploy locks), the performer value must match one of:
 
-```
-gh config get -h github.com [USERNAME]
-```
+1. **The user's GitHub profile URL** — set automatically when signing in with GitHub OAuth (e.g. `https://github.com/yourname`). The Shipyrd gem will use this format if you have your GitHub username configured locally via `gh config set -h github.com user yourname`.
+2. **The user's email address** — matched against email addresses associated with the user's Shipyrd account.
 
 ## Upgrading
 
 When you're ready to upgrade to a newer version of Shipyrd it's just a matter of bumping the version in your _deploy.yml_ file and then rebooting the accessory via Kamal.
 
-1. Change the version(`v4.0.4`) in the image reference line in your _deploy.yml_ file.
+1. Change the version(`v4.4.0`) in the image reference line in your _deploy.yml_ file.
 
 ```
-image: shipyrd/shipyrd:v4.0.4
+image: shipyrd/shipyrd:v4.4.0
 ```
 
 2. Reboot the accessory via Kamal.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Fixed incorrect references — `app/models/channels/` directory (doesn't exist, Channel is a polymorphic model), `ApiKey` token auth (uses `User.token` directly), and `IncomingWebhooksController` (Stripe webhooks are handled by `Incoming::StripeController`)
- **README.md**: Updated stale version numbers from `v0.3.5`/`v4.0.4` to `v4.4.0`, and rewrote the "Customizing the deploy performer" section to accurately describe how performer matching works for deploy locks (matches GitHub profile URL or email address)