### PR TITLE
Add new users to Brevo product updates list

### DIFF
--- a/app/jobs/add_to_brevo_list_job.rb
+++ b/app/jobs/add_to_brevo_list_job.rb
@@ -1,0 +1,14 @@
+class AddToBrevoListJob < ApplicationJob
+  PRODUCT_UPDATES_LIST_ID = 3
+
+  def perform(user_id)
+    user = User.find(user_id)
+
+    api = Brevo::ContactsApi.new
+    contact = Brevo::CreateContact.new
+    contact.email = user.email
+    contact.list_ids = [PRODUCT_UPDATES_LIST_ID]
+    contact.update_enabled = true
+    api.create_contact(contact)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
 
   after_create :store_email_address
   after_create_commit :queue_populate_avatar
+  after_create_commit :enqueue_add_to_brevo_list
 
   scope :has_password, -> { where.not(password_digest: nil) }
 
@@ -88,6 +89,11 @@ class User < ApplicationRecord
     return if user_info["avatar_url"].blank?
 
     update!(avatar_url: "#{user_info["avatar_url"]}&s=100")
+  end
+
+  def enqueue_add_to_brevo_list
+    return if ENV["COMMUNITY_EDITION"] != "0"
+    AddToBrevoListJob.perform_later(id)
   end
 
   private

--- a/config/initializers/brevo.rb
+++ b/config/initializers/brevo.rb
@@ -1,0 +1,5 @@
+if ENV["BREVO_API_KEY"].present?
+  Brevo.configure do |config|
+    config.api_key["api-key"] = ENV["BREVO_API_KEY"]
+  end
+end

--- a/test/jobs/add_to_brevo_list_job_test.rb
+++ b/test/jobs/add_to_brevo_list_job_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class AddToBrevoListJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  describe "perform" do
+    it "creates a Brevo contact with the user's email on the product updates list" do
+      user = create(:user, email: "new@example.com")
+
+      api_instance = mock
+      Brevo::ContactsApi.expects(:new).returns(api_instance)
+      api_instance.expects(:create_contact).with { |contact|
+        assert_equal "new@example.com", contact.email
+        assert_equal [3], contact.list_ids
+        assert_equal true, contact.update_enabled
+      }
+
+      AddToBrevoListJob.perform_now(user.id)
+    end
+  end
+
+  describe "enqueue on user create" do
+    setup do
+      ENV["COMMUNITY_EDITION"] = "0"
+    end
+
+    teardown do
+      ENV.delete("COMMUNITY_EDITION")
+    end
+
+    it "enqueues the job when a user is created" do
+      assert_enqueued_with(job: AddToBrevoListJob) do
+        create(:user)
+      end
+    end
+
+    it "does not enqueue the job in community edition" do
+      ENV["COMMUNITY_EDITION"] = "1"
+
+      assert_no_enqueued_jobs only: AddToBrevoListJob do
+        create(:user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- When a new user is created, a background job (`AddToBrevoListJob`) adds them to the Brevo contact list for Shipyrd product updates (list ID 3).
- Configures the Brevo API client via a new initializer, reusing the existing `BREVO_API_KEY` env var.
- Gated behind `COMMUNITY_EDITION` so it only runs for SAAS deployments.
- Uses `update_enabled: true` so existing Brevo contacts are updated rather than erroring.