### PR TITLE
Fix Docker build by adding libcurl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM base AS build
 RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=dev-apt-lib,sharing=locked,target=/var/lib/apt \
     apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git default-libmysqlclient-dev libyaml-dev
+    apt-get install --no-install-recommends -y build-essential git default-libmysqlclient-dev libcurl4-openssl-dev libyaml-dev
 
 # Install application gems
 COPY Gemfile Gemfile.lock .ruby-version ./
@@ -65,7 +65,7 @@ ENV PORT=$PORT
 RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=dev-apt-lib,sharing=locked,target=/var/lib/apt \
     apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl default-mysql-client && \
+    apt-get install --no-install-recommends -y curl libcurl4 default-mysql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application


### PR DESCRIPTION
The Docker build was failing during asset precompilation because `brevo-rails` depends on `typhoeus` → `ethon` → `ffi`, which requires `libcurl` at load time. This adds `libcurl4-openssl-dev` to the build stage and `libcurl4` to the runtime stage.