### PR TITLE
Only configure Brevo mailer for non-community edition

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,11 +60,13 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # ActionMailer via Brevo API
-  config.action_mailer.delivery_method = :brevo
-  config.action_mailer.brevo_settings = {
-    api_key: ENV.fetch("BREVO_API_KEY")
-  }
+  # ActionMailer via Brevo API (non-community edition only)
+  if ENV["COMMUNITY_EDITION"] == "0"
+    config.action_mailer.delivery_method = :brevo
+    config.action_mailer.brevo_settings = {
+      api_key: ENV.fetch("BREVO_API_KEY")
+    }
+  end
   config.action_mailer.default_url_options = {host: ENV["SHIPYRD_HOST"], protocol: "https"}
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
## Summary

The Docker build was failing during `assets:precompile` because `ENV.fetch("BREVO_API_KEY")` raises a `KeyError` when the env var isn't set at build time. This wraps the Brevo ActionMailer configuration in a `COMMUNITY_EDITION == "0"` check so it's only configured for non-community builds where the API key is available. Community edition falls back to the default Rails mailer delivery method.