### PR TITLE
Add sort order for applications on the dashboard

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -59,6 +59,27 @@ progress.green {
   user-select: all;
 }
 
+.application-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sort-arrows {
+  display: flex;
+  gap: 0.15rem;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.application-row:hover .sort-arrows {
+  opacity: 1;
+}
+
+.sort-arrows .button {
+  text-decoration: none;
+}
+
 .signup-divider {
   position: relative;
 }

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,11 +1,11 @@
 class ApplicationsController < ApplicationController
   skip_before_action :check_email_verification, only: %i[index new create]
   before_action :check_payment_required
-  before_action :set_application, only: %i[show edit update destroy setup]
+  before_action :set_application, only: %i[show edit update destroy setup move_up move_down]
 
   # GET /applications or /applications.json
   def index
-    @applications = current_organization.applications.order(created_at: :desc)
+    @applications = current_organization.applications.order(sort_order: :asc, created_at: :desc)
   end
 
   # GET /applications/1 or /applications/1.json
@@ -49,6 +49,16 @@ class ApplicationsController < ApplicationController
         format.json { render json: @application.errors, status: :unprocessable_content }
       end
     end
+  end
+
+  def move_up
+    @application.decrement!(:sort_order)
+    redirect_to applications_url
+  end
+
+  def move_down
+    @application.increment!(:sort_order)
+    redirect_to applications_url
   end
 
   # DELETE /applications/1 or /applications/1.json

--- a/app/views/applications/_application.html.erb
+++ b/app/views/applications/_application.html.erb
@@ -1,17 +1,34 @@
 <%= turbo_stream_from application %>
 
-<div id="<%= dom_id application %>" class="mb-6">
-  <h2 class="is-size-2 has-text-weight-medium">
-    <%= link_to application.display_name, application_path(application), title: 'View this application' %>
+<div id="<%= dom_id application %>" class="mb-6 application-row">
+  <div class="application-header">
+    <h2 class="is-size-2 has-text-weight-medium">
+      <%= link_to application.display_name, application_path(application), title: 'View this application' %>
 
-    <% if params[:action] == "show" || params[:action].nil? %>
-      <%= link_to edit_application_path(application), class: "mt-4 button is-small" do %>
-        <span class="icon is-small">
-          <i class="fa-solid fa-edit"></i>
-        </span>
+      <% if params[:action] == "show" || params[:action].nil? %>
+        <%= link_to edit_application_path(application), class: "mt-4 button is-small" do %>
+          <span class="icon is-small">
+            <i class="fa-solid fa-edit"></i>
+          </span>
+        <% end %>
       <% end %>
+    </h2>
+
+    <% if params[:action] == "index" || params[:action].nil? %>
+      <span class="sort-arrows">
+        <%= button_to move_up_application_path(application), method: :patch, class: "button is-small is-white" do %>
+          <span class="icon is-small">
+            <i class="fa-solid fa-arrow-up"></i>
+          </span>
+        <% end %>
+        <%= button_to move_down_application_path(application), method: :patch, class: "button is-small is-white" do %>
+          <span class="icon is-small">
+            <i class="fa-solid fa-arrow-down"></i>
+          </span>
+        <% end %>
+      </span>
     <% end %>
-  </h2>
+  </div>
 
   <% if application.destinations.latest.empty? %>
     <div class="notification ">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
   resources :applications do
     member do
       get :setup
+      patch :move_up
+      patch :move_down
     end
     resources :channels, only: %i[edit update destroy]
     resources :webhooks, only: %i[new create]

--- a/db/migrate/20260413000001_add_sort_order_to_applications.rb
+++ b/db/migrate/20260413000001_add_sort_order_to_applications.rb
@@ -1,0 +1,5 @@
+class AddSortOrderToApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :applications, :sort_order, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_162127) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.json "properties"
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_162127) do
     t.bigint "organization_id"
     t.string "repository_url"
     t.string "service"
+    t.integer "sort_order", default: 0, null: false
     t.string "token"
     t.datetime "updated_at", null: false
     t.index ["organization_id"], name: "index_applications_on_organization_id"

--- a/test/controllers/applications_controller_test.rb
+++ b/test/controllers/applications_controller_test.rb
@@ -77,6 +77,34 @@ class ApplicationsControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to edit_application_url(@application)
     end
 
+    test "should move application up" do
+      @application.update!(sort_order: 5)
+
+      patch move_up_application_url(@application)
+
+      assert_redirected_to applications_url
+      assert_equal 4, @application.reload.sort_order
+    end
+
+    test "should move application down" do
+      @application.update!(sort_order: 5)
+
+      patch move_down_application_url(@application)
+
+      assert_redirected_to applications_url
+      assert_equal 6, @application.reload.sort_order
+    end
+
+    test "should order applications by sort_order" do
+      app_b = create(:application, organization: @organization, sort_order: -1)
+
+      get applications_url
+
+      assert_response :success
+      apps = assigns(:applications)
+      assert_equal app_b, apps.first
+    end
+
     test "should destroy application" do
       assert_difference("Application.count", -1) do
         delete application_url(@application)

--- a/test/controllers/applications_controller_test.rb
+++ b/test/controllers/applications_controller_test.rb
@@ -101,8 +101,7 @@ class ApplicationsControllerTest < ActionDispatch::IntegrationTest
       get applications_url
 
       assert_response :success
-      apps = assigns(:applications)
-      assert_equal app_b, apps.first
+      assert_match(/#{app_b.display_name}.*#{@application.display_name}/m, response.body)
     end
 
     test "should destroy application" do


### PR DESCRIPTION
## Summary

- Adds a `sort_order` column to applications so users can reorder them on the dashboard
- Up/down arrow buttons appear on hover for each application on the index page
- Applications are ordered by `sort_order` ascending, then `created_at` descending as a tiebreaker
- Includes controller tests for move up, move down, and ordering behavior

## Test plan

- [ ] Run `bin/ci` to verify all tests pass
- [ ] Verify up/down arrows appear on hover on the applications index
- [ ] Confirm clicking arrows reorders applications as expected