### PR TITLE
Security hardening: XSS fix, CSP, timeouts, and permissions policy

### DIFF
--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -14,13 +14,15 @@ module ApplicationsHelper
 
   def display_commit_message(commit_message, application)
     return nil if commit_message.blank?
-    return commit_message if application.repository_url.blank? || application.repository_url !~ /github/
+    return commit_message if application.repository_url.blank?
+    return commit_message unless application.repository_url.match?(%r{\Ahttps://(github|gitlab)\.com/})
 
     display_message = commit_message.dup
     commit_message.scan(/#(\d+)/).flatten.each do |issue_number|
+      issue_url = "#{application.repository_url}/issues/#{ERB::Util.url_encode(issue_number)}"
       display_message.gsub!(
         "##{issue_number}",
-        "<a href='#{application.repository_url}/issues/#{issue_number}'>##{issue_number}</a>"
+        "<a href='#{ERB::Util.html_escape(issue_url)}'>##{issue_number}</a>"
       )
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,10 @@ class User < ApplicationRecord
 
   def populate_avatar_url
     url = URI("https://api.github.com/users/#{github_username}")
-    user_info = JSON.parse(Net::HTTP.get(url))
+    response = Net::HTTP.start(url.host, url.port, use_ssl: true, open_timeout: 5, read_timeout: 10) do |http|
+      http.request(Net::HTTP::Get.new(url.path))
+    end
+    user_info = JSON.parse(response.body)
 
     return if user_info["avatar_url"].blank?
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -18,7 +18,7 @@ class Webhook < ApplicationRecord
   def notify(event, details)
     logger.debug "Notifying #{url} of #{event} with #{details}"
 
-    Faraday.new do |f|
+    Faraday.new(request: {timeout: 10, open_timeout: 5}) do |f|
       f.request :json
       f.response :logger, Rails.logger if Rails.env.development?
     end.post(url) do |r|

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,19 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src :self, :data
+    policy.img_src :self, :https, :data
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self, :unsafe_inline
+    policy.connect_src :self
+    policy.frame_ancestors :none
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -3,11 +3,12 @@
 # Define an application-wide HTTP permissions policy. For further
 # information see: https://developers.google.com/web/updates/2018/06/feature-policy
 
-# Rails.application.config.permissions_policy do |policy|
-#   policy.camera      :none
-#   policy.gyroscope   :none
-#   policy.microphone  :none
-#   policy.usb         :none
-#   policy.fullscreen  :self
-#   policy.payment     :self, "https://secure.example.com"
-# end
+Rails.application.config.permissions_policy do |policy|
+  policy.camera :none
+  policy.gyroscope :none
+  policy.microphone :none
+  policy.usb :none
+  policy.fullscreen :self
+  policy.payment :none
+  policy.geolocation :none
+end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -30,7 +30,7 @@ class Slack
   private
 
   def send_message(channel_id:, message:)
-    Faraday.new do |faraday|
+    Faraday.new(request: {timeout: 10, open_timeout: 5}) do |faraday|
       faraday.request :json
       faraday.response :logger, Rails.logger if Rails.env.development?
     end.post("https://slack.com/api/chat.postMessage") do |req|

--- a/test/helpers/applications_helper_test.rb
+++ b/test/helpers/applications_helper_test.rb
@@ -19,7 +19,7 @@ class ApplicationsHelperTest < ActionView::TestCase
     it "returns the commit message if blank or unsupported repository url" do
       assert_equal "Changed this thing #22, #43", display_commit_message("Changed this thing #22, #43", @application)
 
-      @application.update!(repository_url: "https://gitlab.com/u/r")
+      @application.update!(repository_url: "https://bitbucket.org/u/r")
       assert_equal "Changed this thing #22", display_commit_message("Changed this thing #22", @application)
     end
 
@@ -30,6 +30,16 @@ class ApplicationsHelperTest < ActionView::TestCase
       assert_equal(
         "Fixed: <a href='#{issues_url}/22'>#22</a>, <a href='#{issues_url}/34'>#34</a>",
         display_commit_message("Fixed: #22, #34", @application)
+      )
+    end
+
+    it "links to all issues if gitlab repository URL is set" do
+      @application.update!(repository_url: "https://gitlab.com/u/r")
+      issues_url = "#{@application.repository_url}/issues"
+
+      assert_equal(
+        "Changed this thing <a href='#{issues_url}/22'>#22</a>",
+        display_commit_message("Changed this thing #22", @application)
       )
     end
   end


### PR DESCRIPTION
## Summary

- **XSS fix**: `display_commit_message` now enforces `https://` protocol with strict `github.com`/`gitlab.com` domain matching and HTML-escapes href values, preventing `javascript:` URI injection via crafted repository URLs.
- **Content Security Policy**: Enabled with restrictive defaults (`default_src :self`, `object_src :none`, `frame_ancestors :none`) and script nonces.
- **HTTP timeouts**: Added 10s read / 5s connect timeouts to all outbound HTTP calls (webhook notifications, Slack API, GitHub avatar fetches) to prevent worker exhaustion.
- **Permissions Policy**: Enabled to block unnecessary browser features (camera, microphone, geolocation, USB, payment).