### PR TITLE
Rephrase deployment dashboard copy to be product-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This App Does
 
-Shipyrd is a deployment dashboard for [Kamal](https://kamal-deploy.org/)-based deployments. It tracks deploy lifecycle events, manages deployment locks, integrates with GitHub, and dispatches notifications to Slack/Discord/etc.
+Shipyrd is a deployment dashboard for your team. It tracks deploy lifecycle events, manages deployment locks, integrates with GitHub, and dispatches notifications to Slack/Discord/etc.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shipyrd
 
-The simple deployment dashboard for Kamal-based deployments.
+The deployment dashboard for your team.
 
 [![production](https://img.shields.io/endpoint?url=https://badge.shipyrd.io/applications/gSBbC8Um5MUjwLXKtW2kABdF/destinations/production/badge/deploy.json)](https://app.shipyrd.io) [![production](https://img.shields.io/endpoint?url=https://badge.shipyrd.io/applications/gSBbC8Um5MUjwLXKtW2kABdF/destinations/production/badge/lock.json)](https://app.shipyrd.io)
 

--- a/app/views/applications/_setup.html.erb
+++ b/app/views/applications/_setup.html.erb
@@ -3,13 +3,7 @@
   <%= button_to "Delete application", application_path(application), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete #{application.name}?" }, class: "button is-danger" %>
 </div>
 
-<div class="tabs is-boxed">
-  <ul>
-    <li class="<%= "is-active" unless params[:tab] %>"><%= link_to "Kamal", setup_application_url(application) %></li>
-    <li class="<%= "is-active" if params[:tab] == "curl" %>"><%= link_to "cURL", setup_application_url(application, tab: "curl") %></li>
-    <li><%= link_to "Honeybadger", new_application_incoming_webhook_url(application, provider: :honeybadger) %></li>
-  </ul>
-</div>
+<%= render "setup_tabs", application: application, active_tab: params[:tab] == "curl" ? :curl : :kamal %>
 
 <% if params[:tab] == "curl" %>
   <%= render "setup_curl", application: application %>

--- a/app/views/applications/_setup_curl.html.erb
+++ b/app/views/applications/_setup_curl.html.erb
@@ -1,3 +1,7 @@
+<div class="content">
+  <h3>How to setup cURL with Shipyrd</h3>
+</div>
+
 <section class="content block">
   <p>
     Application API key:

--- a/app/views/applications/_setup_kamal.html.erb
+++ b/app/views/applications/_setup_kamal.html.erb
@@ -1,3 +1,7 @@
+<div class="content">
+  <h3>How to setup Kamal with Shipyrd</h3>
+</div>
+
 <section class="content block">
   <p>
     Application API key:

--- a/app/views/applications/_setup_tabs.html.erb
+++ b/app/views/applications/_setup_tabs.html.erb
@@ -1,0 +1,7 @@
+<div class="tabs is-boxed">
+  <ul>
+    <li class="<%= "is-active" if active_tab == :kamal %>"><%= link_to "Kamal", setup_application_url(application) %></li>
+    <li class="<%= "is-active" if active_tab == :curl %>"><%= link_to "cURL", setup_application_url(application, tab: "curl") %></li>
+    <li class="<%= "is-active" if active_tab == :honeybadger %>"><%= link_to "Honeybadger", new_application_incoming_webhook_url(application, provider: :honeybadger) %></li>
+  </ul>
+</div>

--- a/app/views/applications/index.html.erb
+++ b/app/views/applications/index.html.erb
@@ -62,7 +62,7 @@
               <span class="icon has-text-primary mb-1">
                 <i class="fa-solid fa-gear"></i>
               </span>
-              <p class="is-size-7 has-text-grey-dark has-text-weight-medium">Configure Kamal hooks</p>
+              <p class="is-size-7 has-text-grey-dark has-text-weight-medium">Configure deploy hooks</p>
             </div>
             <div class="column is-narrow is-flex is-align-items-center">
               <span class="icon is-small has-text-grey-light">

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -3,7 +3,7 @@
     <div class="has-text-centered mb-5">
       <h1 class="title is-3 mb-3">Add an application</h1>
       <p class="subtitle is-5 has-text-grey">
-        Connect your Kamal-deployed app to start tracking deployments and notifying your team.
+        Connect your app to start tracking deployments and notifying your team.
       </p>
     </div>
 

--- a/app/views/billing/setup.html.erb
+++ b/app/views/billing/setup.html.erb
@@ -40,7 +40,7 @@
                   <br>
 
                   I've been working on Shipyrd in my nights and weekends to build
-                  the deployment dashboard for Kamal that I've always wanted.
+                  the deployment dashboard for my team that I've always wanted.
                   <br>
 
                   <em>Thanks for your support, it means a lot.</em>

--- a/app/views/incoming_webhooks/honeybadger/_instructions.html.erb
+++ b/app/views/incoming_webhooks/honeybadger/_instructions.html.erb
@@ -4,8 +4,7 @@
   <p>
     If you're using Honeybadger for error and deploy tracking
     you can utilize a Honeybadger webhook to let Shipyrd know
-    about new deploys instead of adding hooks to Kamal in
-    <code>.kamal/hooks</code>.
+    about new deploys.
   </p>
 
   <h4>Setup instructions</h4>

--- a/app/views/incoming_webhooks/new.html.erb
+++ b/app/views/incoming_webhooks/new.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "New incoming webhook" %>
 
-<h1 class="is-size-2 mb-4">New incoming webhook for <%= params[:provider].humanize %></h1>
+<div class="is-flex is-justify-content-space-between is-align-items-center">
+  <h2 class="is-size-2">Setup <%= @application.name %></h2>
+  <%= button_to "Delete application", application_path(@application), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete #{@application.name}?" }, class: "button is-danger" %>
+</div>
+
+<%= render "applications/setup_tabs", application: @application, active_tab: :honeybadger %>
 
 <%= render "form", incoming_webhook: @incoming_webhook %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
     <div class="has-text-centered mb-5">
       <h1 class="title is-3 mb-4">Know what's deployed. Always.</h1>
       <p class="subtitle is-5 has-text-grey">
-        The deployment dashboard for Kamal. See who deployed, what changed, and what's waiting to go out.
+        The deployment dashboard for your team. See who deployed, what changed, and what's waiting to go out.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- Removes Kamal-specific language across the app, repositioning Shipyrd as "the deployment dashboard for your team"
- Extracts setup tabs into a shared `_setup_tabs` partial reused from both the application setup page and the incoming webhooks page
- Adds section headings to the Kamal and cURL setup partials
- Integrates the Honeybadger webhook page into the unified tab navigation with consistent header/delete button pattern

## Test plan

- [ ] Visit the applications index and verify "Configure deploy hooks" text
- [ ] Visit application setup page and confirm tabs work (Kamal, cURL, Honeybadger)
- [ ] Visit the Honeybadger webhook setup via the tab and confirm the active tab highlights correctly
- [ ] Check signup, new application, and billing pages for updated copy