### PR TITLE
Add Rollbar integration for incoming deploy webhooks

### DIFF
--- a/app/controllers/incoming/rollbar_controller.rb
+++ b/app/controllers/incoming/rollbar_controller.rb
@@ -1,0 +1,37 @@
+class Incoming::RollbarController < ApplicationController
+  protect_from_forgery with: :null_session
+  skip_before_action :authenticate
+
+  before_action :validate_event
+
+  def create
+    application = IncomingWebhook.find_by!(
+      provider: :rollbar,
+      token: params[:token]
+    ).application
+
+    deploy = params[:data][:deploy]
+
+    finish_time = deploy[:finish_time].to_i
+    start_time = deploy[:start_time].to_i
+
+    application.deploys.create!(
+      destination: deploy[:environment],
+      recorded_at: Time.zone.at(finish_time),
+      version: deploy[:revision],
+      performer: deploy[:local_username],
+      runtime: finish_time - start_time,
+      command: "deploy",
+      status: "post-deploy",
+      service_version: "#{application.service}@#{deploy[:revision].first(7)}"
+    )
+
+    head :created
+  end
+
+  private
+
+  def validate_event
+    head :ok if params[:event_name] != "deploy"
+  end
+end

--- a/app/helpers/incoming_webhooks_helper.rb
+++ b/app/helpers/incoming_webhooks_helper.rb
@@ -3,6 +3,8 @@ module IncomingWebhooksHelper
     case provider.intern
     when :honeybadger
       "fa-solid fa-otter" # Yes, it's not a honeybadger
+    when :rollbar
+      "fa-solid fa-rotate"
     end
   end
 end

--- a/app/models/incoming_webhook.rb
+++ b/app/models/incoming_webhook.rb
@@ -5,7 +5,8 @@ class IncomingWebhook < ApplicationRecord
   belongs_to :application
 
   enum :provider, {
-    honeybadger: 0
+    honeybadger: 0,
+    rollbar: 1
   }
 
   def display_name
@@ -13,6 +14,6 @@ class IncomingWebhook < ApplicationRecord
   end
 
   def url
-    "https://#{ENV["SHIPYRD_HOOKS_HOST"]}/incoming/honeybadger/#{token}"
+    "https://#{ENV["SHIPYRD_HOOKS_HOST"]}/incoming/#{provider}/#{token}"
   end
 end

--- a/app/views/applications/_setup_tabs.html.erb
+++ b/app/views/applications/_setup_tabs.html.erb
@@ -3,5 +3,6 @@
     <li class="<%= "is-active" if active_tab == :kamal %>"><%= link_to "Kamal", setup_application_url(application) %></li>
     <li class="<%= "is-active" if active_tab == :curl %>"><%= link_to "cURL", setup_application_url(application, tab: "curl") %></li>
     <li class="<%= "is-active" if active_tab == :honeybadger %>"><%= link_to "Honeybadger", new_application_incoming_webhook_url(application, provider: :honeybadger) %></li>
+    <li class="<%= "is-active" if active_tab == :rollbar %>"><%= link_to "Rollbar", new_application_incoming_webhook_url(application, provider: :rollbar) %></li>
   </ul>
 </div>

--- a/app/views/incoming_webhooks/new.html.erb
+++ b/app/views/incoming_webhooks/new.html.erb
@@ -5,6 +5,6 @@
   <%= button_to "Delete application", application_path(@application), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete #{@application.name}?" }, class: "button is-danger" %>
 </div>
 
-<%= render "applications/setup_tabs", application: @application, active_tab: :honeybadger %>
+<%= render "applications/setup_tabs", application: @application, active_tab: params[:provider]&.to_sym %>
 
 <%= render "form", incoming_webhook: @incoming_webhook %>

--- a/app/views/incoming_webhooks/rollbar/_form.html.erb
+++ b/app/views/incoming_webhooks/rollbar/_form.html.erb
@@ -1,0 +1,1 @@
+<%= form.hidden_field :token %>

--- a/app/views/incoming_webhooks/rollbar/_instructions.html.erb
+++ b/app/views/incoming_webhooks/rollbar/_instructions.html.erb
@@ -1,0 +1,31 @@
+<div class="content">
+  <h3>How to setup Rollbar with Shipyrd</h3>
+
+  <p>
+    If you're using Rollbar for error and deploy tracking
+    you can utilize a Rollbar webhook to let Shipyrd know
+    about new deploys.
+  </p>
+
+  <h4>Setup instructions</h4>
+  <ol>
+    <li>Ensure you've configured <a class="is-underlined" target="_blank" href="https://docs.rollbar.com/docs/deploy-tracking">Rollbar deploy tracking</a> for your app.</li>
+    <li>
+      Within your project on Rollbar go to Settings -> Notifications -> Webhook.
+    </li>
+    <li>
+      Within the Webhook notification settings configure the following:
+      <ul>
+        <li>For the URL, enter <code class="user-select-all"><%= incoming_webhook.url %></code></li>
+        <li>Enable the "Deploy" trigger and disable all others.</li>
+      </ul>
+    </li>
+    <li>Click "Save Settings" in Rollbar.</li>
+    <li>
+      Click the "Create Incoming Webhook" button below.
+    </li>
+    <li>
+      Deploy your application and you'll see updates in Shipyrd!
+    </li>
+  </ol>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :incoming do
     post "honeybadger/:token", action: :create, controller: :honeybadger, as: :honeybadger
+    post "rollbar/:token", action: :create, controller: :rollbar, as: :rollbar
     post "stripe", action: :create, controller: :stripe, as: :stripe
   end
 

--- a/test/controllers/incoming/rollbar_controller_test.rb
+++ b/test/controllers/incoming/rollbar_controller_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class RollbarControllerTest < ActionDispatch::IntegrationTest
+  let(:token) { SecureRandom.hex(32) }
+  let(:application) { create(:application, service: "app") }
+  let(:incoming_webhook) do
+    application.incoming_webhooks.create(
+      provider: :rollbar,
+      token: token
+    )
+  end
+
+  test "fails on invalid token" do
+    post incoming_rollbar_url("invalid"),
+      params: {event_name: "deploy"}
+
+    assert_response :not_found
+  end
+
+  test "only processes deploy events" do
+    IncomingWebhook.expects(:find_by!).never
+
+    post incoming_rollbar_url(incoming_webhook.token),
+      params: {event_name: "new_item"}
+
+    assert_response :ok
+  end
+
+  test "creates a deploy event" do
+    rollbar = {
+      event_name: "deploy",
+      data: {
+        deploy: {
+          comment: "deploying webs",
+          user_id: 1,
+          finish_time: 1382656039,
+          start_time: 1382656038,
+          id: 187585,
+          environment: "production",
+          project_id: 90,
+          local_username: "nick",
+          revision: "1234567abcdef"
+        }
+      }
+    }
+
+    post incoming_rollbar_url(incoming_webhook.token),
+      params: rollbar
+
+    deploy = application.deploys.last
+    rollbar_deploy = rollbar[:data][:deploy]
+
+    assert_response :created
+    assert_equal deploy.destination, rollbar_deploy[:environment]
+    assert_equal deploy.recorded_at, Time.zone.at(rollbar_deploy[:finish_time])
+    assert_equal deploy.version, rollbar_deploy[:revision]
+    assert_equal deploy.performer, rollbar_deploy[:local_username]
+    assert_equal deploy.runtime, rollbar_deploy[:finish_time] - rollbar_deploy[:start_time]
+    assert_equal deploy.status, "post-deploy"
+    assert_equal deploy.command, "deploy"
+    assert_equal deploy.service_version, "app@1234567"
+  end
+end

--- a/test/system/incoming/rollbar_test.rb
+++ b/test/system/incoming/rollbar_test.rb
@@ -1,0 +1,32 @@
+require "application_system_test_case"
+
+class Incoming::RollbarTest < ApplicationSystemTestCase
+  setup do
+    @application = create(:application)
+    @organization = @application.organization
+    @user = create(:user)
+    @organization.memberships.create(user: @user)
+
+    sign_in_as(@user.email, @user.password)
+  end
+
+  test "setting up a rollbar incoming webhook" do
+    visit setup_application_path(@application)
+
+    click_on "Rollbar"
+
+    assert_text "How to setup Rollbar with Shipyrd"
+
+    click_on "Create Incoming webhook"
+
+    assert_text "Incoming webhook was successfully created"
+    assert_text "Disconnect Rollbar"
+
+    accept_confirm do
+      click_on "Disconnect Rollbar"
+    end
+
+    assert_text "Incoming webhook was successfully destroyed"
+    assert_no_text "Disconnect Rollbar"
+  end
+end


### PR DESCRIPTION
Adds Rollbar as a new incoming webhook provider alongside Honeybadger. When Rollbar sends a deploy webhook, Shipyrd creates a Deploy record with environment, revision, performer, and timing data. Includes a Rollbar tab on the setup page with configuration instructions, controller tests, and a system test covering the full setup and disconnect flow. Also generalizes the IncomingWebhook#url method to dynamically use the provider name and makes the setup tab bar highlight the active provider.