### PR TITLE
Add AppSignal integration for incoming deploy webhooks

### DIFF
--- a/app/controllers/incoming/appsignal_controller.rb
+++ b/app/controllers/incoming/appsignal_controller.rb
@@ -28,6 +28,6 @@ class Incoming::AppsignalController < ApplicationController
   private
 
   def validate_event
-    head :ok unless params[:marker].present?
+    head :ok if params[:marker].blank?
   end
 end

--- a/app/controllers/incoming/appsignal_controller.rb
+++ b/app/controllers/incoming/appsignal_controller.rb
@@ -1,0 +1,33 @@
+class Incoming::AppsignalController < ApplicationController
+  protect_from_forgery with: :null_session
+  skip_before_action :authenticate
+
+  before_action :validate_event
+
+  def create
+    application = IncomingWebhook.find_by!(
+      provider: :appsignal,
+      token: params[:token]
+    ).application
+
+    revision = params[:marker][:revision]
+
+    application.deploys.create!(
+      destination: params[:marker][:environment],
+      recorded_at: params[:marker][:time],
+      version: revision,
+      performer: params[:marker][:user],
+      command: "deploy",
+      status: "post-deploy",
+      service_version: "#{application.service}@#{revision.first(7)}"
+    )
+
+    head :created
+  end
+
+  private
+
+  def validate_event
+    head :ok unless params[:marker].present?
+  end
+end

--- a/app/helpers/incoming_webhooks_helper.rb
+++ b/app/helpers/incoming_webhooks_helper.rb
@@ -5,6 +5,8 @@ module IncomingWebhooksHelper
       "fa-solid fa-otter" # Yes, it's not a honeybadger
     when :rollbar
       "fa-solid fa-rotate"
+    when :appsignal
+      "fa-solid fa-signal"
     end
   end
 end

--- a/app/models/incoming_webhook.rb
+++ b/app/models/incoming_webhook.rb
@@ -6,7 +6,8 @@ class IncomingWebhook < ApplicationRecord
 
   enum :provider, {
     honeybadger: 0,
-    rollbar: 1
+    rollbar: 1,
+    appsignal: 2
   }
 
   def display_name

--- a/app/views/applications/_setup_tabs.html.erb
+++ b/app/views/applications/_setup_tabs.html.erb
@@ -4,5 +4,6 @@
     <li class="<%= "is-active" if active_tab == :curl %>"><%= link_to "cURL", setup_application_url(application, tab: "curl") %></li>
     <li class="<%= "is-active" if active_tab == :honeybadger %>"><%= link_to "Honeybadger", new_application_incoming_webhook_url(application, provider: :honeybadger) %></li>
     <li class="<%= "is-active" if active_tab == :rollbar %>"><%= link_to "Rollbar", new_application_incoming_webhook_url(application, provider: :rollbar) %></li>
+    <li class="<%= "is-active" if active_tab == :appsignal %>"><%= link_to "AppSignal", new_application_incoming_webhook_url(application, provider: :appsignal) %></li>
   </ul>
 </div>

--- a/app/views/incoming_webhooks/appsignal/_form.html.erb
+++ b/app/views/incoming_webhooks/appsignal/_form.html.erb
@@ -1,0 +1,1 @@
+<%= form.hidden_field :token %>

--- a/app/views/incoming_webhooks/appsignal/_instructions.html.erb
+++ b/app/views/incoming_webhooks/appsignal/_instructions.html.erb
@@ -1,0 +1,31 @@
+<div class="content">
+  <h3>How to setup AppSignal with Shipyrd</h3>
+
+  <p>
+    If you're using AppSignal for error and deploy tracking
+    you can utilize an AppSignal webhook to let Shipyrd know
+    about new deploys.
+  </p>
+
+  <h4>Setup instructions</h4>
+  <ol>
+    <li>Ensure you've configured <a class="is-underlined" target="_blank" href="https://docs.appsignal.com/application/markers/deploy-markers.html">AppSignal deploy markers</a> for your app.</li>
+    <li>
+      Within your app on AppSignal go to App Settings -> Notifications -> Webhook.
+    </li>
+    <li>
+      Within the Webhook notification settings configure the following:
+      <ul>
+        <li>For the URL, enter <code class="user-select-all"><%= incoming_webhook.url %></code></li>
+        <li>Enable the "Deploy marker" trigger and disable all others.</li>
+      </ul>
+    </li>
+    <li>Click "Save" in AppSignal.</li>
+    <li>
+      Click the "Create Incoming Webhook" button below.
+    </li>
+    <li>
+      Deploy your application and you'll see updates in Shipyrd!
+    </li>
+  </ol>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   namespace :incoming do
     post "honeybadger/:token", action: :create, controller: :honeybadger, as: :honeybadger
     post "rollbar/:token", action: :create, controller: :rollbar, as: :rollbar
+    post "appsignal/:token", action: :create, controller: :appsignal, as: :appsignal
     post "stripe", action: :create, controller: :stripe, as: :stripe
   end
 

--- a/test/controllers/incoming/appsignal_controller_test.rb
+++ b/test/controllers/incoming/appsignal_controller_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class AppsignalControllerTest < ActionDispatch::IntegrationTest
+  let(:token) { SecureRandom.hex(32) }
+  let(:application) { create(:application, service: "app") }
+  let(:incoming_webhook) do
+    application.incoming_webhooks.create(
+      provider: :appsignal,
+      token: token
+    )
+  end
+
+  test "fails on invalid token" do
+    post incoming_appsignal_url("invalid"),
+      params: {marker: {environment: "production"}}
+
+    assert_response :not_found
+  end
+
+  test "creates a deploy event" do
+    appsignal = {
+      marker: {
+        time: "2026-01-13T13:10:04.978277Z",
+        environment: "production",
+        revision: "1234567abcdef",
+        user: "nick",
+        site: "My App"
+      }
+    }
+
+    post incoming_appsignal_url(incoming_webhook.token),
+      params: appsignal
+
+    deploy = application.deploys.last
+    appsignal_marker = appsignal[:marker]
+
+    assert_response :created
+    assert_equal deploy.destination, appsignal_marker[:environment]
+    assert_equal deploy.recorded_at, appsignal_marker[:time]
+    assert_equal deploy.version, appsignal_marker[:revision]
+    assert_equal deploy.performer, appsignal_marker[:user]
+    assert_equal deploy.status, "post-deploy"
+    assert_equal deploy.command, "deploy"
+    assert_equal deploy.service_version, "app@1234567"
+  end
+end

--- a/test/system/incoming/appsignal_test.rb
+++ b/test/system/incoming/appsignal_test.rb
@@ -1,0 +1,32 @@
+require "application_system_test_case"
+
+class Incoming::AppsignalTest < ApplicationSystemTestCase
+  setup do
+    @application = create(:application)
+    @organization = @application.organization
+    @user = create(:user)
+    @organization.memberships.create(user: @user)
+
+    sign_in_as(@user.email, @user.password)
+  end
+
+  test "setting up an appsignal incoming webhook" do
+    visit setup_application_path(@application)
+
+    click_on "AppSignal"
+
+    assert_text "How to setup AppSignal with Shipyrd"
+
+    click_on "Create Incoming webhook"
+
+    assert_text "Incoming webhook was successfully created"
+    assert_text "Disconnect Appsignal"
+
+    accept_confirm do
+      click_on "Disconnect Appsignal"
+    end
+
+    assert_text "Incoming webhook was successfully destroyed"
+    assert_no_text "Disconnect Appsignal"
+  end
+end


### PR DESCRIPTION
Adds AppSignal as a new incoming webhook provider alongside Honeybadger and Rollbar. When AppSignal fires a deploy marker webhook, Shipyrd creates a Deploy record mapped from the `marker` payload fields (`environment`, `time`, `revision`, `user`). Includes an AppSignal tab on the setup page with configuration instructions, a `validate_event` guard, controller tests, and a system test covering the full setup and disconnect flow.