### PR TITLE
Improve Rollbar webhook integration

### DIFF
--- a/app/controllers/incoming/rollbar_controller.rb
+++ b/app/controllers/incoming/rollbar_controller.rb
@@ -14,15 +14,17 @@ class Incoming::RollbarController < ApplicationController
 
     finish_time = deploy[:finish_time].to_i
     start_time = deploy[:start_time].to_i
+    pre_deploy = deploy[:status] == "started"
 
     application.deploys.create!(
       destination: deploy[:environment],
-      recorded_at: Time.zone.at(finish_time),
+      recorded_at: pre_deploy ? Time.zone.at(start_time) : Time.zone.at(finish_time),
       version: deploy[:revision],
       performer: deploy[:local_username],
-      runtime: finish_time - start_time,
+      runtime: pre_deploy ? nil : finish_time - start_time,
+      commit_message: deploy[:comment],
       command: "deploy",
-      status: "post-deploy",
+      status: pre_deploy ? "pre-deploy" : "post-deploy",
       service_version: "#{application.service}@#{deploy[:revision].first(7)}"
     )
 

--- a/app/views/incoming_webhooks/rollbar/_instructions.html.erb
+++ b/app/views/incoming_webhooks/rollbar/_instructions.html.erb
@@ -17,7 +17,12 @@
       Within the Webhook notification settings configure the following:
       <ul>
         <li>For the URL, enter <code class="user-select-all"><%= incoming_webhook.url %></code></li>
-        <li>Enable the "Deploy" trigger and disable all others.</li>
+        <li>
+          In the Rules section, delete any existing rules until only the
+          <strong>Deploy &rarr; Post to Webhook</strong> rule remains. If it isn't there, select
+          <strong>Deploy &rarr; Post to Webhook</strong> from the Template dropdown and click
+          <strong>Configure Rule</strong> to add it.
+        </li>
       </ul>
     </li>
     <li>Click "Save Settings" in Rollbar.</li>

--- a/test/controllers/incoming/rollbar_controller_test.rb
+++ b/test/controllers/incoming/rollbar_controller_test.rb
@@ -26,7 +26,7 @@ class RollbarControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test "creates a deploy event" do
+  test "creates a post-deploy event for succeeded status" do
     rollbar = {
       event_name: "deploy",
       data: {
@@ -39,7 +39,8 @@ class RollbarControllerTest < ActionDispatch::IntegrationTest
           environment: "production",
           project_id: 90,
           local_username: "nick",
-          revision: "1234567abcdef"
+          revision: "1234567abcdef",
+          status: "succeeded"
         }
       }
     }
@@ -56,8 +57,71 @@ class RollbarControllerTest < ActionDispatch::IntegrationTest
     assert_equal deploy.version, rollbar_deploy[:revision]
     assert_equal deploy.performer, rollbar_deploy[:local_username]
     assert_equal deploy.runtime, rollbar_deploy[:finish_time] - rollbar_deploy[:start_time]
+    assert_equal deploy.commit_message, rollbar_deploy[:comment]
     assert_equal deploy.status, "post-deploy"
     assert_equal deploy.command, "deploy"
     assert_equal deploy.service_version, "app@1234567"
+  end
+
+  test "creates a pre-deploy event for started status" do
+    rollbar = {
+      event_name: "deploy",
+      data: {
+        deploy: {
+          comment: "deploying webs",
+          user_id: 1,
+          start_time: 1382656038,
+          id: 187585,
+          environment: "production",
+          project_id: 90,
+          local_username: "nick",
+          revision: "1234567abcdef",
+          status: "started"
+        }
+      }
+    }
+
+    post incoming_rollbar_url(incoming_webhook.token),
+      params: rollbar
+
+    deploy = application.deploys.last
+    rollbar_deploy = rollbar[:data][:deploy]
+
+    assert_response :created
+    assert_equal deploy.destination, rollbar_deploy[:environment]
+    assert_equal deploy.recorded_at, Time.zone.at(rollbar_deploy[:start_time])
+    assert_equal deploy.version, rollbar_deploy[:revision]
+    assert_equal deploy.performer, rollbar_deploy[:local_username]
+    assert_nil deploy.runtime
+    assert_equal deploy.commit_message, rollbar_deploy[:comment]
+    assert_equal deploy.status, "pre-deploy"
+    assert_equal deploy.command, "deploy"
+    assert_equal deploy.service_version, "app@1234567"
+  end
+
+  test "defaults to post-deploy for unrecognized status" do
+    rollbar = {
+      event_name: "deploy",
+      data: {
+        deploy: {
+          comment: "deploying webs",
+          user_id: 1,
+          finish_time: 1382656039,
+          start_time: 1382656038,
+          id: 187585,
+          environment: "production",
+          project_id: 90,
+          local_username: "nick",
+          revision: "1234567abcdef",
+          status: "failed"
+        }
+      }
+    }
+
+    post incoming_rollbar_url(incoming_webhook.token),
+      params: rollbar
+
+    assert_response :created
+    assert_equal application.deploys.last.status, "post-deploy"
   end
 end


### PR DESCRIPTION
Maps Rollbar's `started` deploy status to `pre-deploy` and `succeeded` (or any other value) to `post-deploy`, aligning with Shipyrd's deploy lifecycle. Also stores the Rollbar deploy `comment` as `commit_message` and updates the setup instructions to reflect Rollbar's current Rules-based webhook UI.