### PR TITLE
Add GitHub Actions deploy steps and failed hook support

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,7 @@
   --orange: hsl(39, 100%, 50%);
   --yellow: #ffe70f;
   --green: #42dca3;
+  --red: hsl(348, 86%, 53%);
 }
 
 pre code {
@@ -40,6 +41,10 @@ progress.yellow {
 
 progress.green {
   --bulma-progress-value-background-color: var(--green);
+}
+
+progress.red {
+  --bulma-progress-value-background-color: var(--red);
 }
 
 @media (prefers-color-scheme: light) {

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,11 +1,11 @@
 module ApplicationsHelper
   def application_status_color(status)
     case status
-    when "pre-connect"  then "grey"
-    when "pre-build"    then "orange"
-    when "pre-deploy"   then "yellow"
-    when "post-deploy"  then "green"
-    when "failed"       then "red"
+    when "pre-connect" then "grey"
+    when "pre-build" then "orange"
+    when "pre-deploy" then "yellow"
+    when "post-deploy" then "green"
+    when "failed" then "red"
     end
   end
 

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,14 +1,11 @@
 module ApplicationsHelper
   def application_status_color(status)
     case status
-    when "pre-connect"
-      "grey"
-    when "pre-build"
-      "orange"
-    when "pre-deploy"
-      "yellow"
-    when "post-deploy"
-      "green"
+    when "pre-connect"  then "grey"
+    when "pre-build"    then "orange"
+    when "pre-deploy"   then "yellow"
+    when "post-deploy"  then "green"
+    when "failed"       then "red"
     end
   end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -73,10 +73,10 @@ class Deploy < ApplicationRecord
   def progress_value
     case status
     when "pre-connect" then 1
-    when "pre-build"   then 2
-    when "pre-deploy"  then 3
+    when "pre-build" then 2
+    when "pre-deploy" then 3
     when "post-deploy" then 4
-    when "failed"      then 4
+    when "failed" then 4
     end
   end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -10,7 +10,7 @@ class Deploy < ApplicationRecord
   validate :version_is_valid, on: :create
   validate :destination_deploy_block_state, on: :create
 
-  KNOWN_HOOKS = %w[pre-deploy post-deploy].freeze
+  KNOWN_HOOKS = %w[pre-deploy post-deploy failed].freeze
 
   def full_command
     "#{command} #{subcommand}"
@@ -72,14 +72,11 @@ class Deploy < ApplicationRecord
 
   def progress_value
     case status
-    when "pre-connect"
-      1
-    when "pre-build"
-      2
-    when "pre-deploy"
-      3
-    when "post-deploy"
-      4
+    when "pre-connect" then 1
+    when "pre-build"   then 2
+    when "pre-deploy"  then 3
+    when "post-deploy" then 4
+    when "failed"      then 4
     end
   end
 

--- a/app/views/applications/_setup.html.erb
+++ b/app/views/applications/_setup.html.erb
@@ -3,10 +3,13 @@
   <%= button_to "Delete application", application_path(application), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete #{application.name}?" }, class: "button is-danger" %>
 </div>
 
-<%= render "setup_tabs", application: application, active_tab: params[:tab] == "curl" ? :curl : :kamal %>
+<%= render "setup_tabs", application: application, active_tab: params[:tab]&.to_sym || :kamal %>
 
-<% if params[:tab] == "curl" %>
+<% case params[:tab] %>
+<% when "curl" %>
   <%= render "setup_curl", application: application %>
+<% when "github_actions" %>
+  <%= render "setup_github_actions", application: application %>
 <% else %>
   <%= render "setup_kamal", application: application %>
 <% end %>

--- a/app/views/applications/_setup_github_actions.html.erb
+++ b/app/views/applications/_setup_github_actions.html.erb
@@ -1,0 +1,41 @@
+<div class="content">
+  <h3>How to setup GitHub Actions with Shipyrd</h3>
+</div>
+
+<section class="content block">
+  <p>
+    Deploy token:
+    <code id="application_token_gha">
+    <%= application.token %>
+    </code>
+
+    <button class="button is-small is-white clipboard" data-clipboard-target="#application_token_gha">
+      <span class="icon-text">
+        <span class="icon">
+          <i class="fa-solid fa-copy"></i>
+        </span>
+      </span>
+    </button>
+  </p>
+</section>
+
+<section class="block content">
+  <p>
+    Add <code>SHIPYRD_API_KEY</code> as a GitHub Actions secret in your repository
+    (<strong>Settings &rarr; Secrets and variables &rarr; Actions</strong>) using the deploy token above.
+  </p>
+</section>
+
+<% { "pre-deploy" => nil, "post-deploy" => "success()", "failed" => "failure()" }.each do |hook, condition| %>
+<section class="block content">
+  <h4 class="is-size-4"><%= hook %></h4>
+
+<pre class="mb-2"><code id="gha_<%= hook %>">- name: Notify Shipyrd (<%= hook %>)
+<% if condition %>  if: <%= condition %>
+<% end %>  uses: shipyrd/deploy-action@v1
+  with:
+    api-token: ${{ secrets.SHIPYRD_API_KEY }}
+    status: <%= hook %></code></pre>
+<%= render "shared/copy_to_clipboard", target: "#gha_#{hook}" %>
+</section>
+<% end %>

--- a/app/views/applications/_setup_tabs.html.erb
+++ b/app/views/applications/_setup_tabs.html.erb
@@ -2,6 +2,7 @@
   <ul>
     <li class="<%= "is-active" if active_tab == :kamal %>"><%= link_to "Kamal", setup_application_url(application) %></li>
     <li class="<%= "is-active" if active_tab == :curl %>"><%= link_to "cURL", setup_application_url(application, tab: "curl") %></li>
+    <li class="<%= "is-active" if active_tab == :github_actions %>"><%= link_to "GitHub Actions", setup_application_url(application, tab: "github_actions") %></li>
     <li class="<%= "is-active" if active_tab == :honeybadger %>"><%= link_to "Honeybadger", new_application_incoming_webhook_url(application, provider: :honeybadger) %></li>
     <li class="<%= "is-active" if active_tab == :rollbar %>"><%= link_to "Rollbar", new_application_incoming_webhook_url(application, provider: :rollbar) %></li>
     <li class="<%= "is-active" if active_tab == :appsignal %>"><%= link_to "AppSignal", new_application_incoming_webhook_url(application, provider: :appsignal) %></li>

--- a/app/views/destinations/deploys.html.erb
+++ b/app/views/destinations/deploys.html.erb
@@ -17,7 +17,7 @@
 </div>
 
 <% status_bulma_class = ->(status) {
-  { "green" => "success", "yellow" => "warning", "orange" => "warning", "grey" => "light" }
+  { "green" => "success", "yellow" => "warning", "orange" => "warning", "grey" => "light", "red" => "danger" }
     .fetch(application_status_color(status), "light")
 } %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,4 +86,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Allow act (local GitHub Actions runner) to reach the dev server via Docker
+  config.hosts << "host.docker.internal"
 end


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions setup tab with copyable YAML snippets for `pre-deploy`, `post-deploy`, and `failed` hooks using `shipyrd/deploy-action@v1`
- Adds `failed` to `KNOWN_HOOKS` with corresponding status color (red/danger) and progress tracking
- Adds `host.docker.internal` to allowed hosts in development for local `act` testing

## Test plan
- [ ] Verify GitHub Actions tab renders correctly with all three hook snippets
- [ ] Verify copy-to-clipboard works for each snippet
- [ ] Verify failed deploys show red progress bar and danger tag styling
- [ ] Verify existing deploy statuses still render correctly