### PR TITLE
Link to Shipyrd GitHub Deploy Action in setup view

### DIFF
--- a/app/views/applications/_setup_github_actions.html.erb
+++ b/app/views/applications/_setup_github_actions.html.erb
@@ -1,5 +1,6 @@
 <div class="content">
   <h3>How to setup GitHub Actions with Shipyrd</h3>
+  <p>Use the <a href="https://github.com/Shipyrd/github-deploy-action" target="_blank" style="text-decoration: underline;">Shipyrd GitHub Deploy Action <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a> to notify Shipyrd from your workflows.</p>
 </div>
 
 <section class="content block">


### PR DESCRIPTION
Adds a link to the [Shipyrd GitHub Deploy Action](https://github.com/Shipyrd/github-deploy-action) on the GitHub Actions setup tab so users can easily find the action now that it's live. The link is underlined and includes an external link icon to indicate it opens in a new tab.