### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @nickhammond

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,9 @@ jobs:
       attestations: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -29,10 +32,12 @@ jobs:
           - 3306:3306
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           bundler-cache: true
 
@@ -46,10 +51,12 @@ jobs:
   standardrb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           bundler-cache: true
 
@@ -58,10 +65,12 @@ jobs:
   brakeman:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` (v5.0.1) and `ruby/setup-ruby` (v1.302.0) to full commit SHAs in both workflows, and add `persist-credentials: false` to every checkout so `GITHUB_TOKEN` isn't left on disk for later steps.
- Set workflow-level `permissions: contents: read` on `test.yml` (it had no permissions block and was inheriting the default).
- Add `github-actions` to Dependabot so the new SHA pins get monthly bump PRs, and add `.github/CODEOWNERS` requiring review on `.github/` changes (takes effect once branch protection's "Require review from Code Owners" is enabled).
- Based on the Wiz GitHub Actions security guide and GitHub's secure-use / secure-your-work docs; the three `docker/*` actions in `build.yml` were already SHA-pinned.

## Test plan
- [ ] `Test`, `standardrb`, and `brakeman` jobs pass on this PR
- [ ] `Publish Docker images` diff reviewed (only runs on `main` push / `v*` tags, not on PRs)
- [ ] After merge, enable "Require review from Code Owners" on `main` branch protection