### PR TITLE
Skip Stripe customer creation when API key is not configured

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,7 +14,7 @@ class Membership < ApplicationRecord
 
   def create_stripe_customer
     return false if ENV["COMMUNITY_EDITION"] != "0"
-    return unless Stripe.api_key.present?
+    return if Stripe.api_key.blank?
     return if organization.stripe_customer_id.present?
 
     customer = Stripe::Customer.create(

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,6 +14,7 @@ class Membership < ApplicationRecord
 
   def create_stripe_customer
     return false if ENV["COMMUNITY_EDITION"] != "0"
+    return unless Stripe.api_key.present?
     return if organization.stripe_customer_id.present?
 
     customer = Stripe::Customer.create(

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -6,6 +6,12 @@ class MembershipTest < ActiveSupport::TestCase
   describe "create_stripe_customer" do
     setup do
       ENV["COMMUNITY_EDITION"] = "0"
+      @original_stripe_key = Stripe.api_key
+      Stripe.api_key = "sk_test_dummy"
+    end
+
+    teardown do
+      Stripe.api_key = @original_stripe_key
     end
 
     it "does nothing when organization already has a stripe customer" do
@@ -51,6 +57,20 @@ class MembershipTest < ActiveSupport::TestCase
       assert_no_enqueued_jobs only: CreateStripeCustomerJob do
         organization.memberships.create!(user: user, role: :user)
       end
+    end
+
+    it "does nothing when Stripe.api_key is not configured" do
+      Stripe.api_key = nil
+      organization = create(:organization, stripe_customer_id: nil)
+      user = create(:user)
+
+      Stripe::Customer.expects(:create).never
+
+      perform_enqueued_jobs do
+        organization.memberships.create!(user: user, role: :admin)
+      end
+
+      assert_nil organization.reload.stripe_customer_id
     end
   end
 end


### PR DESCRIPTION
## Summary
- Guards `Membership#create_stripe_customer` with `return unless Stripe.api_key.present?` so admin memberships can be created in environments where Stripe isn't configured (e.g. self-hosted) without `CreateStripeCustomerJob` raising.
- Adds a test covering the new guard and updates the test setup/teardown to manage `Stripe.api_key` around the existing cases.