### PR TITLE
Security hardening: SSRF, CSP, invite links, email verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 /tmp/storage/*
 !/tmp/storage/
 !/tmp/storage/.keep
+/db/*.sqlite3
+/db/*.sqlite3-*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -110,3 +110,40 @@ progress.red {
   border-radius: 4px;
   margin-top: 0.75rem;
 }
+
+.shipyrd-footer-border {
+  border-top: 1px solid hsl(0, 0%, 93%);
+}
+
+.shipyrd-flash-success {
+  color: green;
+}
+
+.shipyrd-flex-gap-sm {
+  gap: 0.5rem;
+}
+
+.shipyrd-flex-gap-md {
+  gap: 0.75rem;
+}
+
+.shipyrd-thread-list {
+  list-style: none;
+  border-left: 2px solid #dbdbdb;
+  padding-left: 0;
+}
+
+.shipyrd-thread-item {
+  padding-left: 0.75rem;
+  position: relative;
+}
+
+.shipyrd-thread-arrow {
+  position: absolute;
+  left: -0.05rem;
+  color: #dbdbdb;
+}
+
+.shipyrd-link-underline {
+  text-decoration: underline;
+}

--- a/app/controllers/billing_controller.rb
+++ b/app/controllers/billing_controller.rb
@@ -16,6 +16,8 @@ class BillingController < ApplicationController
       }]
     )
 
+    raise "Unexpected Stripe checkout URL" unless session.url.to_s.start_with?("https://checkout.stripe.com/")
+
     redirect_to session.url, allow_other_host: true
   end
 end

--- a/app/controllers/email_verifications_controller.rb
+++ b/app/controllers/email_verifications_controller.rb
@@ -1,6 +1,7 @@
 class EmailVerificationsController < ApplicationController
   skip_before_action :authenticate, only: :show
   skip_before_action :check_email_verification
+  before_action :no_referrer, only: :show
 
   rate_limit to: 3, within: 1.hour, only: :create, with: -> { redirect_to new_email_verification_url, alert: "Try again later." }
 
@@ -10,7 +11,7 @@ class EmailVerificationsController < ApplicationController
   def show
     user = User.find_by_token_for(:email_verification, params[:id])
 
-    if user
+    if user && !user.email_verified?
       user.update!(email_verified_at: Time.current)
       redirect_to root_path, notice: "Email verified!"
     else
@@ -21,5 +22,14 @@ class EmailVerificationsController < ApplicationController
   def create
     UserMailer.email_verification(current_user).deliver_later
     redirect_to new_email_verification_path, notice: "Verification email sent. Check your inbox."
+  end
+
+  private
+
+  # The verification token sits in the URL; this stops the browser from
+  # leaking it via the Referer header when the post-verify redirect loads
+  # third-party assets.
+  def no_referrer
+    response.headers["Referrer-Policy"] = "no-referrer"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,18 +40,12 @@ class UsersController < ApplicationController
         @user.errors.add(:base, "Invalid invite link")
 
         format.html { render :new, status: :unprocessable_content }
-      elsif @user.password.present? && @user.save
-        organization = @invite_link&.organization || Organization.create!(name: @user.organization_name)
-        organization.memberships.create(
-          user: @user,
-          role: @invite_link ? @invite_link.role : :admin
-        )
+      elsif @user.password.blank?
+        @user.errors.add(:password, "can't be blank")
 
-        if @invite_link
-          @user.update!(email_verified_at: Time.current)
-        else
-          UserMailer.email_verification(@user).deliver_later
-        end
+        format.html { render :new, status: :unprocessable_content }
+      elsif (organization = create_user_with_organization)
+        UserMailer.email_verification(@user).deliver_later
 
         reset_session
         session[:user_id] = @user.id
@@ -60,8 +54,6 @@ class UsersController < ApplicationController
 
         format.html { redirect_to root_url }
       else
-        @user.errors.add(:password, "can't be blank") if @user.password.blank?
-
         format.html { render :new, status: :unprocessable_content }
       end
     end
@@ -86,6 +78,25 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def create_user_with_organization
+    ApplicationRecord.transaction do
+      @user.save!
+      if @invite_link
+        @invite_link.accept!(@user)
+        @invite_link.organization
+      else
+        org = Organization.create!(name: @user.organization_name)
+        org.memberships.create!(user: @user, role: :admin)
+        org
+      end
+    end
+  rescue ActiveRecord::RecordInvalid
+    nil
+  rescue InviteLink::AlreadyRedeemed
+    @user.errors.add(:base, "Invite link is no longer valid")
+    nil
+  end
 
   def require_self
     redirect_to root_path unless @user.id == current_user.id

--- a/app/models/invite_link.rb
+++ b/app/models/invite_link.rb
@@ -1,24 +1,45 @@
 class InviteLink < ApplicationRecord
   include Role
 
+  class AlreadyRedeemed < RuntimeError; end
+
   belongs_to :creator, class_name: "User", optional: true
   belongs_to :organization
+  belongs_to :redeemed_by, class_name: "User", optional: true,
+    foreign_key: :redeemed_by_user_id
   has_secure_token :code, length: 64
 
   validates :role, inclusion: {in: roles.keys}
 
   before_validation :set_expiration
 
-  scope :active, -> { where(deactivated_at: nil, expires_at: Time.current..) }
+  scope :active, -> {
+    where(deactivated_at: nil, expires_at: Time.current..)
+      .where("role != ? OR redeemed_at IS NULL", roles[:admin])
+  }
   scope :for_role, ->(role) { where(role: role) }
 
   def self.active_for_role(role)
     active.find_by(role: role)
   end
 
+  def single_use?
+    admin?
+  end
+
   def accept!(user)
-    organization.memberships.find_or_create_by(user: user) do |membership|
-      membership.role = role
+    transaction do
+      if single_use?
+        lock!
+        raise AlreadyRedeemed, "Invite link has already been redeemed" if redeemed_at.present?
+      end
+
+      membership = organization.memberships.find_or_create_by(user: user) do |m|
+        m.role = role
+      end
+
+      update!(redeemed_at: Time.current, redeemed_by: user) if single_use?
+      membership
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,9 @@ class User < ApplicationRecord
 
   has_secure_token length: 64
   has_secure_password validations: false
-  generates_token_for :email_verification, expires_in: 24.hours
+  generates_token_for :email_verification, expires_in: 24.hours do
+    email_verified_at&.to_i
+  end
   generates_token_for :unsubscribe, expires_in: 2.weeks
   validates :password, length: {minimum: 10, maximum: 72}, if: -> { password.present? }
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -3,7 +3,7 @@ class Webhook < ApplicationRecord
   belongs_to :application
   has_one :channel, as: :owner, dependent: :destroy
 
-  validates :url, presence: true, url: {no_local: true}
+  validates :url, presence: true, url: {no_local: true, schemes: ["https"]}
 
   after_create :create_channel
 
@@ -18,14 +18,23 @@ class Webhook < ApplicationRecord
   def notify(event, details)
     logger.debug "Notifying #{url} of #{event} with #{details}"
 
-    Faraday.new(request: {timeout: 10, open_timeout: 5}) do |f|
-      f.request :json
-      f.response :logger, Rails.logger if Rails.env.development?
-    end.post(url) do |r|
-      r.headers["Content-Type"] = "application/json"
-      r.body = {
-        event: event
-      }.merge(details).to_json
-    end
+    uri, pinned_ip = UrlSafety.verify!(url)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    http.open_timeout = 5
+    http.read_timeout = 10
+    # Pin the connection to the verified IP so a DNS rebind between verify!
+    # and the actual request cannot redirect us to a private host. The
+    # original hostname is retained for SNI / certificate verification.
+    http.ipaddr = pinned_ip
+
+    request = Net::HTTP::Post.new(uri)
+    request["Content-Type"] = "application/json"
+    request.body = {event: event}.merge(details).to_json
+
+    http.start { |conn| conn.request(request) }
+  rescue UrlSafety::BlockedHostError => e
+    logger.warn "Refusing webhook to #{url}: #{e.message}"
   end
 end

--- a/app/views/applications/_channels.html.erb
+++ b/app/views/applications/_channels.html.erb
@@ -25,9 +25,9 @@
 
         </div>
 
-        <div class="column has-text-right is-flex is-justify-content-flex-end is-align-items-center" style="gap: 0.5rem;">
+        <div class="column has-text-right is-flex is-justify-content-flex-end is-align-items-center shipyrd-flex-gap-sm">
 
-          <%= button_to "Disconnect", application_channel_url(owner, channel), method: :delete, class: "button is-danger", title: "Disconnect #{channel.display_name}", data: { turbo_confirm: "Are you sure?" }, form: { style: "display: inline;" } %>
+          <%= button_to "Disconnect", application_channel_url(owner, channel), method: :delete, class: "button is-danger", title: "Disconnect #{channel.display_name}", data: { turbo_confirm: "Are you sure?" }, form_class: "is-inline" %>
 
           <%= link_to "Edit", edit_application_channel_path(owner, channel), class: "button is-link has-text-white", alt: "Edit #{channel.channel_type} channel"%>
 

--- a/app/views/applications/_setup_github_actions.html.erb
+++ b/app/views/applications/_setup_github_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="content">
   <h3>How to setup GitHub Actions with Shipyrd</h3>
-  <p>Use the <a href="https://github.com/Shipyrd/github-deploy-action" target="_blank" style="text-decoration: underline;">Shipyrd GitHub Deploy Action <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a> to notify Shipyrd from your workflows.</p>
+  <p>Use the <a href="https://github.com/Shipyrd/github-deploy-action" target="_blank" class="shipyrd-link-underline">Shipyrd GitHub Deploy Action <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a> to notify Shipyrd from your workflows.</p>
 </div>
 
 <section class="content block">

--- a/app/views/destinations/deploys.html.erb
+++ b/app/views/destinations/deploys.html.erb
@@ -41,7 +41,7 @@
             <span class="tag is-<%= status_bulma_class.call(latest.status) %> is-light ml-1"><%= latest.status %></span>
           </span>
         </div>
-        <div class="is-flex is-align-items-center" style="gap: 0.75rem;">
+        <div class="is-flex is-align-items-center shipyrd-flex-gap-md">
           <% if latest.compare_url.present? %>
             <%= link_to "Compare changes", latest.compare_url, target: "_blank", class: "button is-info is-small has-text-white" %>
           <% end %>
@@ -56,11 +56,11 @@
       <% end %>
 
       <% if deploy_group.length > 1 %>
-        <ul class="mt-2 ml-2" style="list-style: none; border-left: 2px solid #dbdbdb; padding-left: 0;">
+        <ul class="mt-2 ml-2 shipyrd-thread-list">
           <% deploy_group.reverse_each do |deploy| %>
             <% next if deploy == latest %>
-            <li class="is-size-7 has-text-grey py-1" style="padding-left: 0.75rem; position: relative;">
-              <span style="position: absolute; left: -0.05rem; color: #dbdbdb;">↳</span>
+            <li class="is-size-7 has-text-grey py-1 shipyrd-thread-item">
+              <span class="shipyrd-thread-arrow">↳</span>
               <span class="tag is-<%= status_bulma_class.call(deploy.status) %> is-light is-small mr-1"><%= deploy.status %></span>
               <% seconds = (latest.recorded_at - deploy.recorded_at).to_i %>
               <%= seconds < 60 ? "#{seconds}s" : distance_of_time_in_words(deploy.recorded_at, latest.recorded_at) %> before

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -2,7 +2,7 @@
   Editing
   <%= @application.display_name %>
 
-  <div style="" class="is-inline-block">
+  <div class="is-inline-block">
     <%= destination_tag(@destination) %>
   </div>
 </h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,7 +101,7 @@
     </main>
 
     <% if current_user %>
-      <footer class="mt-6 pt-4" style="border-top: 1px solid hsl(0, 0%, 93%)">
+      <footer class="mt-6 pt-4 shipyrd-footer-border">
         <div class="has-text-centered">
           <p>
             <%= button_to "Sign out", session_path, method: :delete, form_class: "is-inline", class:"has-text-info is-clickable is-underlined" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<p style="color: green"><%= notice %></p>
+<p class="shipyrd-flash-success"><%= notice %></p>
 
 <%= render @user %>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,12 +11,12 @@ Rails.application.configure do
     policy.img_src :self, :https, :data
     policy.object_src :none
     policy.script_src :self
-    policy.style_src :self, :unsafe_inline
+    policy.style_src :self
     policy.connect_src :self
     policy.frame_ancestors :none
   end
 
-  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # Generate per-request nonces for permitted importmap and inline scripts.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  :authorization
 ]

--- a/db/migrate/20260425000002_add_redemption_tracking_to_invite_links.rb
+++ b/db/migrate/20260425000002_add_redemption_tracking_to_invite_links.rb
@@ -1,0 +1,9 @@
+class AddRedemptionTrackingToInviteLinks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :invite_links, :redeemed_at, :datetime
+    add_column :invite_links, :redeemed_by_user_id, :bigint
+
+    add_index :invite_links, :redeemed_by_user_id
+    add_foreign_key :invite_links, :users, column: :redeemed_by_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_000002) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.json "properties"
@@ -186,10 +186,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
     t.datetime "deactivated_at"
     t.datetime "expires_at"
     t.bigint "organization_id"
+    t.datetime "redeemed_at"
+    t.bigint "redeemed_by_user_id"
     t.integer "role"
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_invite_links_on_code", unique: true
     t.index ["creator_id"], name: "index_invite_links_on_creator_id"
+    t.index ["redeemed_by_user_id"], name: "index_invite_links_on_redeemed_by_user_id"
   end
 
   create_table "memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -302,6 +305,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
   add_foreign_key "email_addresses", "users"
   add_foreign_key "incoming_webhooks", "applications"
   add_foreign_key "invite_links", "users", column: "creator_id"
+  add_foreign_key "invite_links", "users", column: "redeemed_by_user_id"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "notifications", "channels"

--- a/lib/url_safety.rb
+++ b/lib/url_safety.rb
@@ -1,0 +1,29 @@
+require "ipaddr"
+require "resolv"
+require "uri"
+
+module UrlSafety
+  class BlockedHostError < StandardError; end
+
+  def self.verify!(url)
+    uri = URI.parse(url.to_s)
+    raise BlockedHostError, "https is required" unless uri.scheme == "https"
+    raise BlockedHostError, "host required" if uri.host.blank?
+
+    addresses = Resolv.getaddresses(uri.host)
+    raise BlockedHostError, "no DNS results for #{uri.host}" if addresses.empty?
+
+    addresses.each do |address|
+      ip = IPAddr.new(address)
+      next unless blocked?(ip)
+      raise BlockedHostError, "blocked address: #{address}"
+    end
+
+    [uri, addresses.first]
+  end
+
+  def self.blocked?(ip)
+    ip.loopback? || ip.private? || ip.link_local? ||
+      ip == IPAddr.new("0.0.0.0") || ip == IPAddr.new("::")
+  end
+end

--- a/test/controllers/email_verifications_controller_test.rb
+++ b/test/controllers/email_verifications_controller_test.rb
@@ -39,6 +39,27 @@ class EmailVerificationsControllerTest < ActionDispatch::IntegrationTest
         assert_equal "Verification link is invalid or has expired.", flash[:alert]
       end
     end
+
+    test "rejects token reuse after verification" do
+      user = create(:user, :unverified)
+      token = user.generate_token_for(:email_verification)
+
+      get email_verification_url(token)
+      assert_redirected_to root_path
+
+      get email_verification_url(token)
+      assert_redirected_to new_session_path
+      assert_equal "Verification link is invalid or has expired.", flash[:alert]
+    end
+
+    test "sets Referrer-Policy: no-referrer" do
+      user = create(:user, :unverified)
+      token = user.generate_token_for(:email_verification)
+
+      get email_verification_url(token)
+
+      assert_equal "no-referrer", response.headers["Referrer-Policy"]
+    end
   end
 
   describe "new (verification required page)" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -82,6 +82,20 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           assert user.organizations.last.admin?(user)
           assert_equal user.organizations.last, @organization
         end
+
+        test "rolls back user creation when an admin invite link has already been redeemed" do
+          invite_link = @organization.invite_links.create!(role: :admin)
+          invite_link.accept!(create(:user))
+
+          user = build(:user)
+
+          assert_no_difference("User.count") do
+            post users_url, params: {code: invite_link.code, user: {email: user.email, name: user.name, password: "secretsecret"}}
+          end
+
+          assert_response :unprocessable_content
+          assert_nil User.find_by(email: user.email)
+        end
       end
     end
   end

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -18,7 +18,7 @@ class WebhooksControllerTest < ActionDispatch::IntegrationTest
 
   test "should create webhook" do
     assert_difference("Webhook.count") do
-      post application_webhooks_url(@application), params: {webhook: {url: "http://example.com"}}
+      post application_webhooks_url(@application), params: {webhook: {url: "https://example.com"}}
     end
 
     assert_redirected_to edit_application_url(@application)
@@ -27,6 +27,14 @@ class WebhooksControllerTest < ActionDispatch::IntegrationTest
   test "should not create webhook with invalid params" do
     assert_no_difference("Webhook.count") do
       post application_webhooks_url(@application), params: {webhook: {url: ""}}
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test "should not create webhook with http scheme" do
+    assert_no_difference("Webhook.count") do
+      post application_webhooks_url(@application), params: {webhook: {url: "http://example.com"}}
     end
 
     assert_response :unprocessable_content

--- a/test/lib/url_safety_test.rb
+++ b/test/lib/url_safety_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class UrlSafetyTest < ActiveSupport::TestCase
+  test "permits public https hosts" do
+    Resolv.stubs(:getaddresses).returns(["93.184.216.34"])
+    assert UrlSafety.verify!("https://example.com/hooks")
+  end
+
+  test "rejects http scheme" do
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("http://example.com/")
+    end
+  end
+
+  test "rejects loopback addresses" do
+    Resolv.stubs(:getaddresses).returns(["127.0.0.1"])
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("https://example.com/")
+    end
+  end
+
+  test "rejects RFC1918 private addresses" do
+    %w[10.0.0.1 172.16.0.1 192.168.1.1].each do |addr|
+      Resolv.stubs(:getaddresses).returns([addr])
+      assert_raises(UrlSafety::BlockedHostError, "expected #{addr} to be blocked") do
+        UrlSafety.verify!("https://example.com/")
+      end
+    end
+  end
+
+  test "rejects link-local (cloud metadata) addresses" do
+    Resolv.stubs(:getaddresses).returns(["169.254.169.254"])
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("https://example.com/")
+    end
+  end
+
+  test "rejects IPv6 loopback and link-local" do
+    %w[::1 fe80::1].each do |addr|
+      Resolv.stubs(:getaddresses).returns([addr])
+      assert_raises(UrlSafety::BlockedHostError, "expected #{addr} to be blocked") do
+        UrlSafety.verify!("https://example.com/")
+      end
+    end
+  end
+
+  test "rejects unsupported schemes" do
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("file:///etc/passwd")
+    end
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("gopher://example.com/")
+    end
+  end
+
+  test "rejects when DNS returns no addresses" do
+    Resolv.stubs(:getaddresses).returns([])
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("https://nope.invalid/")
+    end
+  end
+
+  test "rejects when any resolved address is private" do
+    Resolv.stubs(:getaddresses).returns(["93.184.216.34", "10.0.0.1"])
+    assert_raises(UrlSafety::BlockedHostError) do
+      UrlSafety.verify!("https://example.com/")
+    end
+  end
+end

--- a/test/models/destination_test.rb
+++ b/test/models/destination_test.rb
@@ -69,7 +69,7 @@ class DestinationTest < ActiveSupport::TestCase
   it "dispatch_notifications" do
     destination = create(:destination, application: @application)
     user = create(:user)
-    webhook = @application.webhooks.create!(user: user, url: "http://example.com")
+    webhook = @application.webhooks.create!(user: user, url: "https://example.com")
     channel = webhook.channel
     event = :lock
 

--- a/test/models/invite_link_test.rb
+++ b/test/models/invite_link_test.rb
@@ -20,4 +20,53 @@ class InviteLinkTest < ActiveSupport::TestCase
 
     assert_not_nil invite_link.expires_at
   end
+
+  test "admin invite links are single_use" do
+    assert build(:invite_link, role: :admin).single_use?
+    refute build(:invite_link, role: :user).single_use?
+  end
+
+  test "accept! on an admin link marks redemption and refuses reuse" do
+    invite_link = create(:invite_link, role: :admin)
+    user_a = create(:user)
+    user_b = create(:user)
+
+    invite_link.accept!(user_a)
+
+    invite_link.reload
+    assert_not_nil invite_link.redeemed_at
+    assert_equal user_a, invite_link.redeemed_by
+
+    assert_raises(InviteLink::AlreadyRedeemed) { invite_link.accept!(user_b) }
+    refute invite_link.organization.memberships.exists?(user: user_b)
+  end
+
+  test "accept! on a user link allows multiple redemptions and leaves redeemed_at nil" do
+    invite_link = create(:invite_link, role: :user)
+    user_a = create(:user)
+    user_b = create(:user)
+
+    invite_link.accept!(user_a)
+    invite_link.accept!(user_b)
+
+    invite_link.reload
+    assert_nil invite_link.redeemed_at
+    assert_nil invite_link.redeemed_by
+    assert invite_link.organization.memberships.exists?(user: user_a)
+    assert invite_link.organization.memberships.exists?(user: user_b)
+  end
+
+  test "active scope excludes redeemed admin links but keeps user links" do
+    admin_link = create(:invite_link, role: :admin)
+    user_link = create(:invite_link, role: :user)
+
+    assert_includes InviteLink.active, admin_link
+    assert_includes InviteLink.active, user_link
+
+    admin_link.accept!(create(:user))
+    user_link.accept!(create(:user))
+
+    refute_includes InviteLink.active, admin_link.reload
+    assert_includes InviteLink.active, user_link.reload
+  end
 end

--- a/test/models/user_email_verification_test.rb
+++ b/test/models/user_email_verification_test.rb
@@ -57,4 +57,13 @@ class UserEmailVerificationTest < ActiveSupport::TestCase
       assert_nil User.find_by_token_for(:email_verification, token)
     end
   end
+
+  test "email verification token is invalidated after verification" do
+    user = create(:user, :unverified)
+    token = user.generate_token_for(:email_verification)
+
+    user.update!(email_verified_at: Time.current)
+
+    assert_nil User.find_by_token_for(:email_verification, token)
+  end
 end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -39,8 +39,20 @@ class WebhookTest < ActiveSupport::TestCase
       }.to_json)
       .to_return(status: 200)
 
+    Resolv.stubs(:getaddresses).returns(["93.184.216.34"])
     @webhook.notify(:lock, {test: "true"})
 
     assert_requested(stub_request)
+  end
+
+  test "refuses to notify a private-IP host without raising" do
+    @webhook.url = "https://internal.example.com"
+    @webhook.save!
+
+    stub = stub_request(:post, @webhook.url)
+    Resolv.stubs(:getaddresses).returns(["10.0.0.5"])
+
+    assert_nothing_raised { @webhook.notify(:lock, {test: "true"}) }
+    assert_not_requested(stub)
   end
 end


### PR DESCRIPTION
## Summary

- **SSRF in outgoing webhooks**: enforce `https`-only URLs, reject loopback/private/link-local destinations, and pin the Net::HTTP connection to the verified IP so a DNS rebind between the safety check and the request can't redirect us to an internal host.
- **Email verification**: include `email_verified_at` in the verification token signature so it's invalidated after first use, and add `Referrer-Policy: no-referrer` on the verification page so the token can't leak via Referer.
- **Invite links**: admin invites are now single-use with redemption tracked under a row lock; failures during signup roll back the new `User` so we don't leave orphaned accounts.
- **CSP**: drop `'unsafe_inline'` from `style-src`, generate per-request nonces with `SecureRandom`, and migrate the remaining inline styles to classes.
- **Misc**: filter `Authorization` from logs, validate the Stripe checkout URL prefix before redirecting, and gitignore SQLite artifacts.