### PR TITLE
Reorder org edit page and fix button text color in light mode

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -49,8 +49,8 @@ progress.red {
 
 @media (prefers-color-scheme: light) {
 
-  main a,
-  main a:visited {
+  main a:not(.button),
+  main a:not(.button):visited {
     color: #303030;
   }
 }

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,5 +1,3 @@
-<%= render "slack_integration", organization: @organization %>
-
 <%= form_with(model: @organization, class: "contents") do |form| %>
   <%= render "shared/errors", form: form %>
 
@@ -7,6 +5,12 @@
     <%= form.label :name, class: "label" %>
     <div class="control">
       <%= form.text_field :name, class: "input" %>
+    </div>
+  </div>
+
+  <div class="field">
+    <div class="control">
+      <%= form.submit class: "button is-primary" %>
     </div>
   </div>
 
@@ -61,9 +65,5 @@
     </div>
   </div>
 
-  <div class="field">
-    <div class="control">
-      <%= form.submit class: "button is-primary" %>
-    </div>
-  </div>
+  <%= render "slack_integration", organization: @organization %>
 <% end %>


### PR DESCRIPTION
Reorders the organization edit page so the layout reads: Name → submit button → Business Hours → Slack Bot. The Slack Bot section was previously rendered above the form; it now lives at the bottom with its own horizontal rule separator.

Also fixes a bug where link-styled buttons (e.g. "Add to Slack") had their text turn black when clicked in light mode. The `main a` color override in `application.css` now uses `:not(.button)` to exclude Bulma-styled buttons, preserving their intended text color.