### PR TITLE
Add slug to applications for Slack slash command lookups

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -85,6 +85,7 @@ class ApplicationsController < ApplicationController
   def application_params
     params.require(:application).permit(
       :name,
+      :slug,
       :repository_url,
       destinations_attributes: %i[id name branch url _destroy]
     )

--- a/app/controllers/incoming/slack_controller.rb
+++ b/app/controllers/incoming/slack_controller.rb
@@ -151,7 +151,7 @@ class Incoming::SlackController < ApplicationController
       return nil
     end
 
-    app = @organization.applications.find_by("lower(name) = ?", app_name.downcase)
+    app = @organization.applications.find_by(slug: app_name.downcase)
     unless app
       slack_respond("App *#{app_name}* not found.")
       return nil

--- a/app/javascript/controllers/slugify_controller.js
+++ b/app/javascript/controllers/slugify_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["source", "slug"]
+
+  connect() {
+    this.userEdited = this.slugTarget.value.length > 0 &&
+      this.slugTarget.value !== this.slugify(this.sourceTarget.value)
+  }
+
+  update() {
+    if (this.userEdited) return
+    this.slugTarget.value = this.slugify(this.sourceTarget.value)
+  }
+
+  markEdited() {
+    this.userEdited = true
+  }
+
+  slugify(value) {
+    return value
+      .toString()
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+  }
+}

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -27,6 +27,12 @@ class Application < ApplicationRecord
   end
 
   validates :repository_url, url: {allow_blank: true, no_local: true}
+  validates :slug,
+    presence: true,
+    format: {with: /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/, message: "may only contain lowercase letters, numbers, and dashes"},
+    uniqueness: {scope: :organization_id, case_sensitive: false}
+
+  before_validation :generate_slug
 
   broadcasts_refreshes # When an application is created, updated, or destroyed a refresh is streamed to "applications"
   broadcasts # For broadcasting deploys as they come in
@@ -38,7 +44,7 @@ class Application < ApplicationRecord
   end
 
   def display_name
-    name.presence || key
+    name.presence || slug
   end
 
   def current_status(destination:)
@@ -55,5 +61,26 @@ class Application < ApplicationRecord
 
   def repository_username
     repository_url.split("/").slice(-2)
+  end
+
+  private
+
+  def generate_slug
+    return if slug.present?
+
+    base = (name.presence || key).to_s.parameterize
+    return if base.blank?
+
+    candidate = base
+    counter = 1
+    scope = self.class.where(organization_id: organization_id)
+    scope = scope.where.not(id: id) if persisted?
+
+    while scope.where(slug: candidate).exists?
+      counter += 1
+      candidate = "#{base}-#{counter}"
+    end
+
+    self.slug = candidate
   end
 end

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -1,11 +1,19 @@
-<%= form_with(model: application, class: "contents") do |form| %>
+<%= form_with(model: application, class: "contents", data: {controller: "slugify"}) do |form| %>
   <%= render "shared/errors", form: form %>
 
   <div class="field">
     <%= form.label :name, class: "label" %>
     <div class="control">
-      <%= form.text_field :name, class: "input", placeholder: "My App" %>
+      <%= form.text_field :name, class: "input", placeholder: "My App", data: {slugify_target: "source", action: "input->slugify#update"} %>
     </div>
+  </div>
+
+  <div class="field">
+    <%= form.label :slug, class: "label" %>
+    <div class="control">
+      <%= form.text_field :slug, class: "input", placeholder: "my-app", data: {slugify_target: "slug", action: "input->slugify#markEdited"} %>
+    </div>
+    <p class="help">Used in Slack commands and notifications. Auto-fills from the name.</p>
   </div>
 
   <div class="field">

--- a/db/migrate/20260428000001_add_slug_to_applications.rb
+++ b/db/migrate/20260428000001_add_slug_to_applications.rb
@@ -1,0 +1,18 @@
+class AddSlugToApplications < ActiveRecord::Migration[8.1]
+  def up
+    add_column :applications, :slug, :string
+
+    Application.reset_column_information
+    Application.find_each do |application|
+      slug = (application.name.presence || application.key).to_s.parameterize
+      application.update_columns(slug: slug) if slug.present?
+    end
+
+    add_index :applications, [:organization_id, :slug], unique: true
+  end
+
+  def down
+    remove_index :applications, [:organization_id, :slug]
+    remove_column :applications, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_25_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_000001) do
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.json "properties"
@@ -46,9 +46,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_000002) do
     t.bigint "organization_id"
     t.string "repository_url"
     t.string "service"
+    t.string "slug"
     t.integer "sort_order", default: 0, null: false
     t.string "token"
     t.datetime "updated_at", null: false
+    t.index ["organization_id", "slug"], name: "index_applications_on_organization_id_and_slug", unique: true
     t.index ["organization_id"], name: "index_applications_on_organization_id"
     t.index ["token"], name: "index_applications_on_token", unique: true
   end

--- a/lib/slack/status_blocks.rb
+++ b/lib/slack/status_blocks.rb
@@ -66,11 +66,14 @@ class Slack
     end
 
     def app_name_cell(application)
-      rich_text_section_cell([{
-        type: "link",
-        url: application_url(application, host: ENV["SHIPYRD_HOST"], protocol: "https"),
-        text: application.name
-      }])
+      rich_text_section_cell([
+        {
+          type: "link",
+          url: application_url(application, host: ENV["SHIPYRD_HOST"], protocol: "https"),
+          text: application.name
+        },
+        {type: "text", text: " (`#{application.slug}`)"}
+      ])
     end
 
     def rich_text_section_cell(elements)

--- a/test/controllers/incoming/slack_controller_test.rb
+++ b/test/controllers/incoming/slack_controller_test.rb
@@ -147,6 +147,17 @@ class Incoming::SlackControllerTest < ActionDispatch::IntegrationTest
     assert response.parsed_body["blocks"].is_a?(Array)
   end
 
+  test "lock finds app by slug" do
+    @membership.update!(slack_user_id: "U123")
+    multi_word_app = create(:application, name: "Pizza Tracker", organization: @organization)
+    destination = create(:destination, application: multi_word_app, name: "production")
+
+    post_signed(text: "lock #{multi_word_app.slug} production")
+
+    assert_response :success
+    assert destination.reload.locked?
+  end
+
   test "usage is returned for unknown command" do
     post_signed(text: "frobnicate")
 

--- a/test/models/application_test.rb
+++ b/test/models/application_test.rb
@@ -4,15 +4,62 @@ class ApplicationTest < ActiveSupport::TestCase
   let(:application) { create(:application, key: "bacon") }
 
   describe "display_name" do
-    it "Prefers name over key" do
+    it "prefers name over slug" do
       application.name = "Bacon"
-      assert_equal application.name, application.display_name
+      assert_equal "Bacon", application.display_name
 
       application.name = nil
-      assert_equal application.key, application.display_name
+      assert_equal application.slug, application.display_name
 
       application.name = ""
-      assert_equal application.key, application.display_name
+      assert_equal application.slug, application.display_name
+    end
+  end
+
+  describe "slug" do
+    it "auto-populates from the name on save" do
+      application = build(:application, name: "Pizza Tracker", slug: nil)
+      application.valid?
+
+      assert_equal "pizza-tracker", application.slug
+    end
+
+    it "preserves a user-provided slug" do
+      application = build(:application, name: "Pizza Tracker", slug: "pt")
+      application.valid?
+
+      assert_equal "pt", application.slug
+    end
+
+    it "rejects invalid slug formats" do
+      application = build(:application, slug: "Not Valid!")
+
+      refute application.valid?
+      assert_includes application.errors[:slug].first, "lowercase"
+    end
+
+    it "appends a counter when a generated slug would collide" do
+      organization = create(:organization)
+      create(:application, organization: organization, name: "Same Name")
+      sibling = create(:application, organization: organization, name: "Same Name")
+
+      assert_equal "same-name-2", sibling.slug
+    end
+
+    it "enforces uniqueness within an organization" do
+      organization = create(:organization)
+      create(:application, organization: organization, slug: "shared")
+      duplicate = build(:application, organization: organization, slug: "shared")
+
+      refute duplicate.valid?
+      assert_includes duplicate.errors[:slug], "has already been taken"
+    end
+
+    it "allows the same slug across organizations" do
+      create(:application, slug: "shared", organization: create(:organization))
+      sibling = build(:application, slug: "shared", organization: create(:organization))
+
+      assert sibling.valid?
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds a `slug` column to `applications` (unique per organization) that auto-populates from the name on save, with a backfill migration.
- Exposes the slug on the application edit form with a `slugify` Stimulus controller that fills it from the name and stops once the user edits the slug field.
- Switches the `/shipyrd` slash command to look up apps by slug (replacing the case-insensitive name match) and adds the slug next to the linked app name in the status table so users see exactly what to type for `lock`/`unlock`/`status`.