### PR TITLE
Show deploy activity timestamps in organization time zone

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -38,6 +38,10 @@ class Organization < ApplicationRecord
     !active_subscription? && !trial_active?
   end
 
+  def selected_time_zone
+    time_zone.present? ? ActiveSupport::TimeZone[time_zone] : Time.zone
+  end
+
   def business_hours_configured?
     time_zone.present? && business_hours_start.present? && business_hours_end.present?
   end

--- a/app/views/destinations/deploys.html.erb
+++ b/app/views/destinations/deploys.html.erb
@@ -42,12 +42,12 @@
           </span>
         </div>
         <div class="is-flex is-align-items-center shipyrd-flex-gap-md">
+          <time class="is-size-7 has-text-grey" datetime="<%= latest.recorded_at %>">
+            <%= latest.recorded_at.in_time_zone(latest.application.organization.selected_time_zone).strftime("%Y-%m-%d %I:%M %p") %>
+          </time>
           <% if latest.compare_url.present? %>
             <%= link_to "Compare changes", latest.compare_url, target: "_blank", class: "button is-info is-small has-text-white" %>
           <% end %>
-          <time class="timeago is-size-7 has-text-grey" datetime="<%= latest.recorded_at %>">
-            <%= time_ago_in_words(latest.recorded_at) %> ago
-          </time>
         </div>
       </div>
 

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -22,6 +22,20 @@ class OrganizationTest < ActiveSupport::TestCase
     refute organization.active_subscription?
   end
 
+  describe "selected_time_zone" do
+    it "returns the configured time zone when set" do
+      organization = create(:organization, time_zone: "Central Time (US & Canada)")
+
+      assert_equal ActiveSupport::TimeZone["Central Time (US & Canada)"], organization.selected_time_zone
+    end
+
+    it "falls back to Time.zone when time_zone is blank" do
+      organization = create(:organization, time_zone: nil)
+
+      assert_equal Time.zone, organization.selected_time_zone
+    end
+  end
+
   describe "business hours" do
     it "returns true for within_business_hours? when no time zone configured" do
       organization = create(:organization, time_zone: nil)


### PR DESCRIPTION
## Summary
- Replace the relative "X ago" timestamp on the destination deploys page with an absolute timestamp formatted in the organization's configured time zone.
- Add `Organization#selected_time_zone` (with tests) that returns the configured zone or falls back to `Time.zone` when unset.