### PR TITLE
add text wrapping to commit messages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -147,3 +147,8 @@ progress.red {
 .shipyrd-link-underline {
   text-decoration: underline;
 }
+
+.shipyrd-text-wrap {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}

--- a/app/views/applications/_destination.html.erb
+++ b/app/views/applications/_destination.html.erb
@@ -86,7 +86,7 @@
 
       <div class="column pt-1 is-three-fifths">
         <small>
-          <em><%= sanitize display_commit_message(deploy.commit_message, application), tags: %w(a), attributes: %w(href) %></em>
+          <em class="shipyrd-text-wrap"><%= sanitize display_commit_message(deploy.commit_message, application), tags: %w(a), attributes: %w(href) %></em>
         </small>
       </div>
 

--- a/app/views/destinations/deploys.html.erb
+++ b/app/views/destinations/deploys.html.erb
@@ -52,7 +52,7 @@
       </div>
 
       <% if latest.commit_message.present? %>
-        <p class="mt-2 is-size-6 has-text-grey-dark"><em><%= sanitize display_commit_message(latest.commit_message, application), tags: %w(a), attributes: %w(href) %></em></p>
+        <p class="mt-2 is-size-6 has-text-grey-dark"><em class="shipyrd-text-wrap"><%= sanitize display_commit_message(latest.commit_message, application), tags: %w(a), attributes: %w(href) %></em></p>
       <% end %>
 
       <% if deploy_group.length > 1 %>


### PR DESCRIPTION
Hey there. I noticed when looking at deployments on smaller screens the commit messages go outside the article boundary. I added some css to help with this

<img width="603" height="1311" alt="Shipyrd" src="https://github.com/user-attachments/assets/54b15527-5e0b-40cc-a955-d2f4243a25fd" />

## Before

<img width="1232" height="1331" alt="Screenshot 2026-07-01 at 4 34 30 PM" src="https://github.com/user-attachments/assets/3d798514-1770-408b-ae25-5d6e5fdd8238" />

## After

<img width="1232" height="1331" alt="Screenshot 2026-07-01 at 4 34 48 PM" src="https://github.com/user-attachments/assets/bfa2022a-5bd4-4054-9c40-51be4b0c230f" />


Thanks for open sourcing this. It's really helpful to see what versions of the self hosting apps I've got deployed